### PR TITLE
set product type to service if it's a pack

### DIFF
--- a/product_pack/models/product.py
+++ b/product_pack/models/product.py
@@ -188,6 +188,9 @@ class product_template(models.Model):
         if vals.get('pack_line_ids', False):
             self.product_variant_ids.write(
                 {'pack_line_ids': vals.pop('pack_line_ids')})
+        # set type to service if it's a pack
+        if vals['pack'] == True:
+            vals['type'] = 'service'
         return super(product_template, self).write(vals)
 
     @api.model

--- a/product_pack/models/product.py
+++ b/product_pack/models/product.py
@@ -189,6 +189,7 @@ class product_template(models.Model):
             self.product_variant_ids.write(
                 {'pack_line_ids': vals.pop('pack_line_ids')})
         # set type to service if it's a pack
+        vals['pack'] = self.pack
         if vals['pack'] == True:
             vals['type'] = 'service'
         return super(product_template, self).write(vals)


### PR DESCRIPTION
This is logical because packs themselves are not products but a bundle of products and the user may not understand this.
forcing the service type will ensure that the system will not try to create stock pickings nor stock journal entries for the pack itself.