### PR TITLE
 [9.0][product_replenishment_cost_rule] FIX sequence 

### DIFF
--- a/product_replenishment_cost_rule/__openerp__.py
+++ b/product_replenishment_cost_rule/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Product Replenshiment Cost Rule",
-    'version': '9.0.1.2.0',
+    'version': '9.0.1.3.0',
     'category': 'Product',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/product_replenishment_cost_rule/models/product_replenishment_cost_rule.py
+++ b/product_replenishment_cost_rule/models/product_replenishment_cost_rule.py
@@ -145,8 +145,8 @@ class ProductReplenishmentCostRuleItem(models.Model):
         auto_join=True,
     )
 
-    sequence = fields.Char(
-        'sequence',
+    sequence = fields.Integer(
+        required=True,
         default=10,
     )
 

--- a/product_replenishment_cost_rule/models/product_replenishment_cost_rule.py
+++ b/product_replenishment_cost_rule/models/product_replenishment_cost_rule.py
@@ -15,7 +15,6 @@ class ProductReplenishmentCostRule(models.Model):
     _inherit = ['mail.thread']
 
     name = fields.Char(
-        'Name',
         required=True,
     )
 
@@ -119,9 +118,15 @@ class ProductReplenishmentCostRule(models.Model):
 
             values[line.name] = error or value
             line.value = error or str(value)
+            line.error = error
             if line.add_to_cost:
                 cost = cost + value
-        return cost
+
+        # Don't compute cost if there are errors
+        if any([line.error for line in self.item_ids]):
+            return False
+        else:
+            return cost
 
     @api.onchange('product_id', 'item_ids')
     def _onchange_product_id(self):
@@ -151,7 +156,6 @@ class ProductReplenishmentCostRuleItem(models.Model):
     )
 
     name = fields.Char(
-        'Name',
         required=True,
     )
 
@@ -186,6 +190,5 @@ class ProductReplenishmentCostRuleItem(models.Model):
     )
 
     # no-op for testing and calculating rule
-    value = fields.Char(
-        compute=lambda x: x,
-    )
+    value = fields.Char(compute=lambda x: x)
+    error = fields.Char(compute=lambda x: x)


### PR DESCRIPTION
Sequence was buggy because it was defined as Char instead of Integer.

Also, to make it easier to detect errors, if there are any the cost won't be computed (instead of silently ignoring the line value)