### PR TITLE
product_currency module raise an error

### DIFF
--- a/product_currency/models/product_template.py
+++ b/product_currency/models/product_template.py
@@ -25,3 +25,10 @@ class ProductTemplate(models.Model):
         super(ProductTemplate, self)._compute_currency_id()
         for rec in self.filtered('force_currency_id'):
             rec.currency_id = rec.force_currency_id
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    company_currency_id = fields.Many2one(
+        related='company_id.currency_id')


### PR DESCRIPTION
When trying to create product from **sellable/purchasable products** menus in **invoicing** module, I got the below error:
_You cannot change the currency of the company since some journal items already exist_

Changes made to this file solve this issue