### PR TITLE
[ADD] product_price_taxes_included: Implement new config in sales

### DIFF
--- a/product_price_taxes_included/README.rst
+++ b/product_price_taxes_included/README.rst
@@ -18,6 +18,7 @@ This modules allow you to see product prices with or without taxes included.
 
 #. Create new field on products that is shown on tree and form that shows "Product Price" with taxes included (on previous versions it was same lst_price field but then you couldn't search and sort by this field, so for siplicity we keep native odoo fields and add our owns)
 #. Also modify pricelist method so that if include_taxes is sent on context you will get prices with taxes included
+#. Add in config of sale the boolean to show price with tax in the product template kanban view.
 
 Installation
 ============

--- a/product_price_taxes_included/__manifest__.py
+++ b/product_price_taxes_included/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Product Price Taxes Included or Not',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Product',
     'sequence': 14,
     'summary': '',
@@ -29,11 +29,13 @@
     'images': [
     ],
     'depends': [
-        'account',
+        'sale',
     ],
     'data': [
+        'security/product_price_taxes_included_security.xml',
         'views/product_template_views.xml',
         'views/product_product_views.xml',
+        'wizards/res_config_settings_views.xml',
     ],
     'demo': [
     ],

--- a/product_price_taxes_included/security/product_price_taxes_included_security.xml
+++ b/product_price_taxes_included/security/product_price_taxes_included_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+
+    <record model="res.groups" id="group_prices_with_tax">
+        <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="name">Products: see the price with tax</field>
+    </record>
+
+</odoo>

--- a/product_price_taxes_included/views/product_template_views.xml
+++ b/product_price_taxes_included/views/product_template_views.xml
@@ -36,4 +36,19 @@
         </field>
     </record>
 
+    <record id="product_template_kanban_view" model="ir.ui.view">
+        <field name="name">product.template.kanban</field>
+        <field name="model">product.template</field>
+        <field name="groups_id" eval="[(4, ref('product_price_taxes_included.group_prices_with_tax'))]"/>
+        <field name="inherit_id" ref="product.product_template_kanban_view"></field>
+        <field name="arch" type="xml">
+            <field name="lst_price" position="after">
+                    <field name="taxed_lst_price"/>
+                </field>
+            <xpath expr="//div[hasclass('oe_kanban_details')]//field[@name='lst_price']" position="after">
+                /                <field name="taxed_lst_price" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/product_price_taxes_included/wizards/__init__.py
+++ b/product_price_taxes_included/wizards/__init__.py
@@ -2,6 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-
-from . import models
-from . import wizards
+from . import res_config_settings

--- a/product_price_taxes_included/wizards/res_config_settings.py
+++ b/product_price_taxes_included/wizards/res_config_settings.py
@@ -1,0 +1,15 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+
+    _inherit = 'res.config.settings'
+
+    group_kanban_prices_with_tax = fields.Boolean(
+        "Price with taxes in kanban view",
+        implied_group='product_price_taxes_included.group_prices_with_tax',
+    )

--- a/product_price_taxes_included/wizards/res_config_settings_views.xml
+++ b/product_price_taxes_included/wizards/res_config_settings_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='sale_management']//div[1]" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="group_kanban_prices_with_tax"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="group_kanban_prices_with_tax"/>
+                        <div class="text-muted">
+                        In the kanban view, in addition to showing the price without
+                        taxes, add the price of the product with taxes.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
To show the price with taxes in kanban of product template, now set a boolean in sales config to set the user to a new group. This activate a view for this group to do that.