### PR TITLE
[PORT] from 11.0

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -93,7 +93,9 @@ class ProductProduct(models.Model):
         packs, no_packs = self.separete_pack_products()
         prices = super(ProductProduct, no_packs).price_compute(
             price_type, uom, currency, company)
-        for product in packs.with_context(prefetch_fields=False):
+        if self._context.get('website_id', False):
+            packs = packs.with_context(prefetch_fields=False)
+        for product in packs:
             pack_price = 0.0
             for pack_line in product.pack_line_ids:
                 product_line_price = pack_line.product_id.price * (


### PR DESCRIPTION
[FIX] product_pack: compute the components prices of packs (#254)

This fix it's becase if you search form backend products and in the result the products that taken are some component of a pack product join a product pack, the prefecth=false broke the compute the lst_price field.
The reason for this prefect are only for the visible of product in website.