### PR TITLE
[PORT] from 11.0

### DIFF
--- a/product_catalog_aeroo_report_public_categ/models/product_catalog_report.py
+++ b/product_catalog_aeroo_report_public_categ/models/product_catalog_report.py
@@ -27,5 +27,5 @@ class ProductCatalogReport(models.Model):
             if self.include_sub_categories and categories:
                 categories = self.env['product.public.category'].search(
                     [('id', 'child_of', categories.ids)])
-                self = self.with_context(category_ids=categories.ids)
+            self = self.with_context(category_ids=categories.ids)
         return self


### PR DESCRIPTION
[FIX] product_catalog_aeroo_report_public_categ: Fix in the method prepare_report (#256)

The self that return in the second if are only if you select subcategories, but if you don't select subcategories the public categories selected are not send by the context