### PR TITLE
[REF] price_security: Remove ugly way to write values

### DIFF
--- a/price_security/__manifest__.py
+++ b/price_security/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Price Security',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'category': 'Sales Management',
     'author': 'ADHOC SA, Odoo Community Association (OCA)',
     'website': 'http://www.adhoc.com.ar/',

--- a/price_security/models/account_invoice_line.py
+++ b/price_security/models/account_invoice_line.py
@@ -9,29 +9,10 @@ from odoo.tools import float_compare
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'
 
-    # we add this fields instead of making original readonly because we need
-    # on change to change values, we make readonly in view because sometimes
-    # we want them to be writeable
-    invoice_line_tax_ids_readonly = fields.Many2many(
-        related='invoice_line_tax_ids',
-        readonly=True,
-    )
-    price_unit_readonly = fields.Float(
-        related='price_unit',
-        readonly=True,
-    )
     product_can_modify_prices = fields.Boolean(
         related='product_id.can_modify_prices',
         readonly=True,
         string='Product Can modify prices')
-
-    @api.onchange('price_unit_readonly')
-    def onchange_price_unit_readonly(self):
-        self.price_unit = self.price_unit_readonly
-
-    @api.onchange('invoice_line_tax_ids_readonly')
-    def onchange_invoice_line_tax_id_readonly(self):
-        self.invoice_line_tax_ids = self.invoice_line_tax_ids_readonly
 
     @api.multi
     @api.constrains(

--- a/price_security/views/account_invoice_views.xml
+++ b/price_security/views/account_invoice_views.xml
@@ -12,21 +12,15 @@
             </xpath>
 
             <!-- add readonly price unit -->
-            <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='price_unit']" position="after">
-                <field name="price_unit_readonly" attrs="{'readonly': [('product_can_modify_prices','=', False)]}"/>
-            </xpath>
-            <!-- make price unit invisible -->
             <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='price_unit']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="attrs">{'readonly': [('product_can_modify_prices','=', False)]}</attribute>
+                <attribute name="force_save">1</attribute>
             </xpath>
 
             <!-- add tax readonly -->
-            <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='invoice_line_tax_ids']" position="after">
-                <field name="invoice_line_tax_ids_readonly" attrs="{'readonly': [('product_can_modify_prices','=', False)]}" context="{'type':parent.type}" domain="[('type_tax_use','=','sale'),('company_id', '=', parent.company_id)]" widget="many2many_tags"/>
-            </xpath>
-            <!-- make tax invisible -->
             <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='invoice_line_tax_ids']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="attrs">{'readonly': [('product_can_modify_prices','=', False)]}</attribute>
+                <attribute name="force_save">1</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In this case the implementation to save values in fields readonly on tree views are solved by the attribute "force_save" in the field insted a ugly way using realted fields and views to do this.