### PR TITLE
[12.0][Fix] product_uoms: Adds new access permission

### DIFF
--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -156,7 +156,8 @@ class ProductTemplate(models.Model):
 
             replenishment_cost_rule = rec.replenishment_cost_rule_id
             replenishment_cost = base_cost_currency._convert(
-                replenishment_base_cost, product_currency, company, date, round=False)
+                replenishment_base_cost, product_currency, company, date,
+                round=False)
 
             replenishment_base_cost_on_currency = replenishment_cost
             if replenishment_cost_rule:

--- a/product_uoms/README.rst
+++ b/product_uoms/README.rst
@@ -62,6 +62,8 @@ Images
 Contributors
 ------------
 
+* Daniel Luque
+
 Maintainer
 ----------
 

--- a/product_uoms/__manifest__.py
+++ b/product_uoms/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Product UOMS',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'base.module_category_knowledge_management',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',

--- a/product_uoms/security/ir.model.access.csv
+++ b/product_uoms/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_product_uoms_all,product_uoms_public,model_product_uoms,,1,0,0,0
+access_product_uoms_manager,product_uoms_manager,model_product_uoms,uom.group_uom,1,1,1,1


### PR DESCRIPTION
Currently, although the user is part of the `uom.group_oum` group, the user can't create, write or unlink records in the `uom_ids` field.

Allows `uom.group_uom` user group to: read, write, create and unlink, in `product.uoms` model.