### PR TITLE
[FIX] product_replenishment_cost: Use related_sudo=False

### DIFF
--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -28,6 +28,7 @@ class ProductTemplate(models.Model):
     )
     standard_price_copy = fields.Float(
         related='standard_price',
+        related_sudo=False,
     )
     replenishment_cost = fields.Float(
         compute='_compute_replenishment_cost',


### PR DESCRIPTION
Becase this related are to property field and when you are logged with an user different that admin are not taken the correct value of the company of the actual user, the take that admin user.