### PR TITLE
[12.0] [FIX] product_uoms_purchase: Fix an error with stock dropshipping

### DIFF
--- a/product_uoms_purchase/models/stock_rule.py
+++ b/product_uoms_purchase/models/stock_rule.py
@@ -11,15 +11,14 @@ class StockRule(models.Model):
     @api.multi
     def _prepare_purchase_order_line(
             self, product_id, product_qty, product_uom, values, po, supplier):
-
         """ We modify this method to set the uom select for purchase in the
         UOMs of the product, by de onchange selected the correctly
         of the line product to avoid an error then when validate in the
          creation of the purchase line.
         """
         res = super()._prepare_purchase_order_line(
-            product_id=product_id, product_qty=product_qty,
-            product_uom=product_uom, values=values, po=po, supplier=supplier)
+            product_id, product_qty,
+            product_uom, values, po, supplier)
 
         purchase_line = self.env['purchase.order.line'].new(res)
         purchase_line.onchange_product_id()


### PR DESCRIPTION
It's not necesarry to use name of variable = variable, this cause an error when the variable name is changed.