### PR TITLE
[FIX] exclude website sales form checking the sale UOM.

### DIFF
--- a/product_uoms_sale/__manifest__.py
+++ b/product_uoms_sale/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Product UOMS Sale',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'base.module_category_knowledge_management',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',

--- a/product_uoms_sale/models/sale_order_line.py
+++ b/product_uoms_sale/models/sale_order_line.py
@@ -42,6 +42,8 @@ class SaleOrderLine(models.Model):
 
     @api.constrains('product_uom')
     def check_uoms(self):
+        if self._context.get('website_id'):
+            return True
         for rec in self:
             product = rec.product_id
             sale_product_uoms = product.get_product_uoms(


### PR DESCRIPTION
Ticket nbr. 23464:

- As the used UOMs in website_sale are Odoo's, we need to adapt this module, because otherway it throws an error.