### PR TITLE
[11.0] [FIX] product_replenishment_cost: the supplier currency use the correct currency

### DIFF
--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -17,11 +17,11 @@ class ProductTemplate(models.Model):
 
     supplier_currency_id = fields.Many2one(
         related='seller_ids.currency_id',
-        readonly=True,
+        compute='_compute_supplier_data',
     )
     supplier_price = fields.Float(
         string='Supplier Price',
-        compute='_compute_supplier_price',
+        compute='_compute_supplier_data',
         digits=dp.get_precision('Product Price'),
     )
     standard_price = fields.Float(
@@ -75,7 +75,7 @@ class ProductTemplate(models.Model):
     )
 
     @api.depends('seller_ids')
-    def _compute_supplier_price(self):
+    def _compute_supplier_data(self):
         """ Lo ideal seria utilizar campo related para que segun los permisos
          del usuario tome el seller_id que corresponda, pero el tema es que el
          cron se corre con admin y entonces siempre va a tomar el primer seller
@@ -90,7 +90,10 @@ class ProductTemplate(models.Model):
         for rec in self.filtered('seller_ids'):
             seller_ids = rec.seller_ids.filtered(
                 lambda x: not x.company_id or x.company_id.id == company_id)
-            rec.supplier_price = seller_ids and seller_ids[0].net_price
+            rec.update({
+                'supplier_price': seller_ids and seller_ids[0].net_price,
+                'supplier_currency_id': seller_ids and seller_ids[0].currency_id.id,
+            })
 
     @api.model
     def cron_update_cost_from_replenishment_cost(self, limit=None):


### PR DESCRIPTION
Before of this changes, for some cases the currency of the supplier is taken of first record of the seller_ids, an the price of supplier is taken who is in the same company as the product , because of that the price and the currency are different and the price computed is wrong. To ensure to use the correct currency of the supplier (who is select by the compute of the price), we use the same compute function to both fields (price & currency) of the supplier.

Ticket Nbr: 27112