### PR TITLE
[IMP] product_replenishment_cost: tree view perf

### DIFF
--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Replenishment Cost',
-    'version': '13.0.1.2.0',
+    'version': '13.0.1.3.0',
     'author': "ADHOC SA, Camptocamp,GRAP,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'category': 'Products',

--- a/product_replenishment_cost/views/product_replenishment_cost_rule_views.xml
+++ b/product_replenishment_cost/views/product_replenishment_cost_rule_views.xml
@@ -47,8 +47,6 @@
         <field name="arch" type="xml">
             <tree string="Replenishment Cost Rule">
                 <field name="name" placeholder="Name..."/>
-                <field name="product_ids"/>
-                <field name="item_ids"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
remove product m2m on tree view due to performance issues when rule is applied to many products
Also remove items as it's not very useful