### PR TITLE
[REM] product_replenishment_cost: rem rule preview

### DIFF
--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Replenishment Cost',
-    'version': '12.0.1.4.0',
+    'version': '12.0.1.5.0',
     'author': "ADHOC SA, Camptocamp, GRAP, Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'category': 'Products',

--- a/product_replenishment_cost/models/product_replenishment_cost_rule.py
+++ b/product_replenishment_cost/models/product_replenishment_cost_rule.py
@@ -43,18 +43,6 @@ class ProductReplenishmentCostRule(models.Model):
         track_visibility='onchange',
     )
 
-    # no-op for testing and calculating rule
-    product_id = fields.Many2one(
-        'product.template',
-        'Test Product',
-        compute=lambda x: x,
-        inverse=lambda x: x,
-        help="Technical field: This field it's only for testing",
-    )
-
-    demo_cost = fields.Float('Cost', compute=lambda x: x)
-    demo_result = fields.Float('Result', compute=lambda x: x)
-
     @api.depends(
         'name',
         'item_ids.name',
@@ -132,25 +120,7 @@ class ProductReplenishmentCostRule(models.Model):
                     pass
 
             values[line.name] = error or value
-            line.update({
-                'value': error or str(value),
-                'error': error,
-            })
             if line.add_to_cost:
                 cost = cost + value
 
-        # Don't compute cost if there are errors
-        if any([line.error for line in self.item_ids]):
-            return False
-        else:
-            return cost
-
-    @api.onchange('product_id', 'item_ids')
-    def _onchange_product_id(self):
-        """ On change to show dynamic results. """
-        if self.product_id:
-            cost = self.product_id.replenishment_base_cost_on_currency
-            self.update({
-                'demo_cost': cost,
-                'demo_result': self.compute_rule(cost, self.product_id),
-            })
+        return cost

--- a/product_replenishment_cost/models/product_replenishment_cost_rule_item.py
+++ b/product_replenishment_cost/models/product_replenishment_cost_rule_item.py
@@ -54,13 +54,3 @@ class ProductReplenishmentCostRuleItem(models.Model):
              'If not, it\'s just a variable.',
         default=True,
     )
-
-    # no-op for testing and calculating rule
-    value = fields.Char(
-        compute=lambda x: x,
-        help="Technical fields: This field it's only for testing",
-    )
-    error = fields.Char(
-        compute=lambda x: x,
-        help="Technical fields: This field it's only for testing",
-    )

--- a/product_replenishment_cost/views/product_replenishment_cost_rule_views.xml
+++ b/product_replenishment_cost/views/product_replenishment_cost_rule_views.xml
@@ -8,11 +8,6 @@
             <form string="Replenishment Cost Rule">
                 <sheet string="Replenishment Cost Rule">
                     <h1><field name="name" placeholder="Name..."/></h1>
-                    <group>
-                        <field name="product_id" options='{"no_open": True,"no_create": 1, "no_create_edit": 1}'/>
-                        <field name="demo_cost" attrs="{'invisible': [('product_id', '=', False)]}"/>
-                        <field name="demo_result" attrs="{'invisible': [('product_id', '=', False)]}"/>
-                    </group>
                     <notebook>
                         <page string="Items">
                             <field name="item_ids">
@@ -23,7 +18,6 @@
                                     <field name="fixed_amount"/>
                                     <field name="expr" groups="product_replenishment_cost.group_replenishment_rule_expr"/>
                                     <field name="add_to_cost" groups="product_replenishment_cost.group_replenishment_rule_expr"/>
-                                    <field name="value"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Toda esta logica no estaba bien implementada y hacía que cualquier acción automatica sobre modelo product_replenishment_cost_rule_item se ejecute cada vez que se entraba en los productos. Como tampoco no se usaba por el momento borramos todo esto.