### PR TITLE
[13.0] [FIX] product_price_taxes_included: Solve a bug with the taxes…

### DIFF
--- a/product_price_taxes_included/models/product_product.py
+++ b/product_price_taxes_included/models/product_product.py
@@ -13,10 +13,10 @@ class ProductProduct(models.Model):
         string='Taxed Sale Price',
         compute='_compute_taxed_lst_price',
         digits='Product Price',
-        compute_sudo=True,
     )
 
     @api.depends('taxes_id', 'lst_price')
+    @api.depends_context('company', 'company_id')
     def _compute_taxed_lst_price(self):
         """ if taxes_included lst_price already has taxes included
         """
@@ -24,7 +24,7 @@ class ProductProduct(models.Model):
             'company_id', self.env.company.id)
         for product in self:
             product.taxed_lst_price = product.taxes_id.filtered(
-                lambda x: x.company_id.id == company_id).compute_all(
+                lambda x: x.company_id.id == company_id).sudo().compute_all(
                     product.lst_price,
                     self.env.company.currency_id,
                     product=product)['total_included']

--- a/product_price_taxes_included/models/product_template.py
+++ b/product_price_taxes_included/models/product_template.py
@@ -20,6 +20,7 @@ class ProductTemplate(models.Model):
     )
 
     @api.depends('taxes_id', 'list_price')
+    @api.depends_context('company', 'company_id')
     def _compute_taxed_lst_price(self):
         """ compute it from list_price and not for lst_price for performance
         (avoid using dummy related field)


### PR DESCRIPTION
… in products variants.

The compute sudo for the field taxed_lst_price is broken when you have more taxes with different companies and you don't have selected all of them in the windows page.