### PR TITLE
[13.0] [FIX] product_replenishment_cost: Create valuation when change standard price.

### DIFF
--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -135,7 +135,7 @@ class ProductTemplate(models.Model):
                     product.standard_price,
                     replenishment_cost,
                     precision_digits=prec) != 0:
-                if product._fields.get('valuation') and product.valuation == 'real_time':
+                if product._fields.get('valuation'):
                     account = product.property_account_creditor_price_difference \
                         or product.categ_id.property_account_creditor_price_difference_categ\
                         or product.property_account_expense_id\


### PR DESCRIPTION

For all the changes in standard prices when use inventory we need to use the method to change standard price and create valuation layer.
Before this change we only create valuation layer if the product has valuation in real time, and odoo method to change price solve this problem for all the cases.