### PR TITLE
[FIX]product_catalog_aeroo_report: temporary fix with null website_id

### DIFF
--- a/product_catalog_aeroo_report/report/parser.py
+++ b/product_catalog_aeroo_report/report/parser.py
@@ -60,7 +60,7 @@ class Parser(models.AbstractModel):
     def get_price(self, product, pricelist):
         # TODO we send "website_id" in the context to compute the price for pack detailed by component,
         # to change this with "whole_pack_price" when this PR https://github.com/OCA/product-pack/pull/46 was merged
-        product_obj = self.env[self.product_type].with_context(pricelist=pricelist.id, website_id=True)
+        product_obj = self.env[self.product_type].with_context(pricelist=pricelist.id, website_id=pricelist.website_id.id or True)
         sale_uom = self.env['product.template'].fields_get(
             ['sale_uom_ids'])
         if sale_uom and product.sale_uom_ids:


### PR DESCRIPTION
until https://github.com/OCA/product-pack/pull/46 is merged we use website_id in the context. This add an if witch prevent of bug in case the pricelist is for the website