### PR TITLE
[13.0] [FIX] product_catalog_aeroo_report: Use the whole_pack_price now for the whole pack price.

### DIFF
--- a/product_catalog_aeroo_report/report/parser.py
+++ b/product_catalog_aeroo_report/report/parser.py
@@ -58,9 +58,7 @@ class Parser(models.AbstractModel):
         return field_value[0].get(field, '')
 
     def get_price(self, product, pricelist):
-        # TODO we send "website_id" in the context to compute the price for pack detailed by component,
-        # to change this with "whole_pack_price" when this PR https://github.com/OCA/product-pack/pull/46 was merged
-        product_obj = self.env[self.product_type].with_context(pricelist=pricelist.id, website_id='website_id' in pricelist._fields and pricelist.website_id.id or True)
+        product_obj = self.env[self.product_type].with_context(whole_pack_price=True)
         sale_uom = self.env['product.template'].fields_get(
             ['sale_uom_ids'])
         if sale_uom and product.sale_uom_ids:


### PR DESCRIPTION
After this [PR](https://github.com/OCA/product-pack/pull/46) was merged we use this new flag