### PR TITLE
[FW][IMP]  show taxed_lst_price and replenishment_cost_last_update fields only for internal users in product_template tree view

### DIFF
--- a/product_price_taxes_included/__manifest__.py
+++ b/product_price_taxes_included/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Product Price Taxes Included or Not',
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
     'category': 'Product',
     'sequence': 14,
     'summary': '',

--- a/product_price_taxes_included/views/product_template_views.xml
+++ b/product_price_taxes_included/views/product_template_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="product.product_template_tree_view"></field>
         <field name="arch" type="xml">
             <field name="list_price" position="after">
-                <field name="taxed_lst_price"/>
+                <field name="taxed_lst_price" groups="base.group_user"/>
             </field>
         </field>
     </record>

--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Replenishment Cost',
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
     'author': "ADHOC SA, Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'category': 'Products',

--- a/product_replenishment_cost/views/product_template_views.xml
+++ b/product_replenishment_cost/views/product_template_views.xml
@@ -53,7 +53,7 @@
         <field name="inherit_id" ref="product.product_template_tree_view"/>
         <field name="arch" type="xml">
             <field name="standard_price" position="after">
-                <field name="replenishment_cost_last_update" optional="hide"/>
+                <field name="replenishment_cost_last_update" optional="hide" groups="base.group_user"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Se realiza este cambio para que dichos campos no se visualicen en la vista tree del módulo portal_sale_distributor.