### PR TITLE
[FIX] product_pricelist: avoiding record rules when calculating price…

### DIFF
--- a/product_pricelist/models/product_pricelist.py
+++ b/product_pricelist/models/product_pricelist.py
@@ -32,8 +32,10 @@ class ProductPricelist(models.Model):
             self.price = 0.0
 
         if active_id and model:
+            product = self.env[model].browse(active_id)
             for rec in self:
-                rec.price = self.env[model].browse(active_id).with_context(pricelist=rec.id)._get_contextual_price()
+                contextual_price = product.with_context(pricelist=rec.id)._get_contextual_price()
+                rec.sudo().write({'price': contextual_price})
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):


### PR DESCRIPTION
… list price through the computed method


When having price_security that has a rule of registry that cannot be written the pricelist gives error when entering the products, therefore when being a computed method the one of the calculation of the price we write it with a sudo().
https://github.com/ingadhoc/product/blob/440ebf105edf72b6ef1d7ab30e6f107d658bed34/price_security/security/price_security_security.xml#L34