### PR TITLE
[FIX] product_pricelist: add sudo in compute price method

### DIFF
--- a/product_pricelist/models/product_pricelist.py
+++ b/product_pricelist/models/product_pricelist.py
@@ -21,6 +21,7 @@ class ProductPricelist(models.Model):
     )
 
     def _compute_price(self):
+        self = self.sudo()
         active_id = model = False
         if 'pricelist_product_id' in self._context:
             active_id = self._context.get('pricelist_product_id')


### PR DESCRIPTION
This is done because if there is a record rule in the pricelist that cannot be edited (for example there is one in the price_security module) this avoids that record rule, there is no problem because it is only to see the price.