### PR TITLE
[IMP] price_security: Ensure unique sequence assignment for payment terms

### DIFF
--- a/price_security/__init__.py
+++ b/price_security/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import models
 from . import wizard
+from .hooks import post_init_hook

--- a/price_security/__manifest__.py
+++ b/price_security/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Price Security",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Sales Management",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "website": "http://www.adhoc.com.ar/",
@@ -38,6 +38,8 @@
         "views/product_template_views.xml",
         "views/res_users_views.xml",
         "views/sale_order_views.xml",
+        "views/product_pricelist_views.xml",
     ],
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/price_security/hooks.py
+++ b/price_security/hooks.py
@@ -1,0 +1,7 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+def post_init_hook(env):
+    terms = env["account.payment.term"].search([], order="id ASC")
+    for idx, term in enumerate(terms, start=1):
+        term.sequence = idx

--- a/price_security/models/account_payment_term.py
+++ b/price_security/models/account_payment_term.py
@@ -8,4 +8,8 @@ from odoo import fields, models
 class AccountPaymentTerm(models.Model):
     _inherit = "account.payment.term"
 
-    sequence = fields.Integer()
+    sequence = fields.Integer(default=lambda self: self._get_default_sequence())
+
+    def _get_default_sequence(self):
+        last_sequence = self.env["account.payment.term"].search([], order="sequence DESC", limit=1).sequence
+        return last_sequence + 1 if last_sequence is not None else 1

--- a/price_security/views/account_payment_term_views.xml
+++ b/price_security/views/account_payment_term_views.xml
@@ -10,4 +10,14 @@
             </field>
         </field>
     </record>
+    <record id="view_payment_term_tree" model="ir.ui.view">
+        <field name="name">account.payment.term.list</field>
+        <field name="model">account.payment.term</field>
+        <field name="inherit_id" ref="account.view_payment_term_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="sequence" optional="hide"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/price_security/views/product_pricelist_views.xml
+++ b/price_security/views/product_pricelist_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="product_pricelist_view_tree" model="ir.ui.view">
+        <field name="name">product.pricelist.list</field>
+        <field name="model">product.pricelist</field>
+        <field name="inherit_id" ref="product.product_pricelist_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="sequence" optional="hide"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION

Added logic to guarantee unique sequence values for each account.payment.term record.

- Implemented a post-init hook to assign incremental sequence values to existing records during module installation.
- Overrode the create() method to automatically assign the next available sequence to newly created payment terms when not explicitly provided.

This prevents duplicate sequence values and ensures proper ordering of payment terms across the system.