### PR TITLE
[IMP] price_security: add pricelist_allowed_ids constraint for restricted users

### DIFF
--- a/price_security/__manifest__.py
+++ b/price_security/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Price Security",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Sales Management",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "website": "http://www.adhoc.com.ar/",

--- a/price_security/models/account_payment_term.py
+++ b/price_security/models/account_payment_term.py
@@ -9,6 +9,14 @@ class AccountPaymentTerm(models.Model):
     _inherit = "account.payment.term"
 
     sequence = fields.Integer(default=lambda self: self._get_default_sequence())
+    payment_term_allowed_ids = fields.Many2many(
+        comodel_name="account.payment.term",
+        relation="account_payment_term_allowed_rel",
+        column1="user_id",
+        column2="payment_term_id",
+        string="Allowed Payment Terms",
+        help="Payment terms that a user with restrictions can select",
+    )
 
     def _get_default_sequence(self):
         last_sequence = self.env["account.payment.term"].search([], order="sequence DESC", limit=1).sequence

--- a/price_security/models/product_pricelist.py
+++ b/price_security/models/product_pricelist.py
@@ -9,3 +9,11 @@ class ProductPricelist(models.Model):
     _inherit = "product.pricelist"
 
     sequence = fields.Integer()
+    pricelist_allowed_ids = fields.Many2many(
+        comodel_name="product.pricelist",
+        relation="product_pricelist_allowed_rel",
+        column1="pricelist_id",
+        column2="allowed_pricelist_id",
+        string="Allowed Pricelists",
+        help="Pricelists that a user with price restriction can select",
+    )

--- a/price_security/models/sale_order.py
+++ b/price_security/models/sale_order.py
@@ -16,19 +16,32 @@ class SaleOrder(models.Model):
         if not self.env.user.has_group("price_security.group_only_view"):
             return True
         if (
-            self.partner_id.property_product_pricelist
-            and self.pricelist_id
-            and self.partner_id.property_product_pricelist.sequence < self.pricelist_id.sequence
-        ):
-            raise UserError(_("Selected pricelist priority can not be higher than pircelist " "configured on partner"))
-        if (
             self.partner_id.property_payment_term_id
             and self.payment_term_id
             and self.partner_id.property_payment_term_id.sequence < self.payment_term_id.sequence
         ):
             raise UserError(
-                _("Selected payment term priority can not be higher than " "payment term configured on partner")
+                _("Selected payment term priority can not be higher than payment term configured on partner")
             )
+
+    @api.constrains("pricelist_id", "partner_id")
+    def check_allowed_pricelist(self):
+        for order in self:
+            if not self.env.user.has_group("price_security.group_only_view"):
+                continue
+
+            partner_pricelist = order.partner_id.property_product_pricelist
+            if not partner_pricelist or not order.pricelist_id:
+                continue
+
+            allowed = partner_pricelist.pricelist_allowed_ids
+
+            if order.pricelist_id not in allowed and order.pricelist_id != partner_pricelist:
+                raise UserError(
+                    _(
+                        "You are not allowed to select this pricelist according to the restrictions configured on the partner"
+                    )
+                )
 
     @api.onchange("partner_id")
     def check_partner_pricelist_change(self):
@@ -38,7 +51,7 @@ class SaleOrder(models.Model):
         if self.order_line and pricelist != self._origin.pricelist_id:
             if self.env.user.has_group("price_security.group_only_view"):
                 self.partner_id = self._origin.partner_id
-                msj = _("You can not change partner if there are sale lines" " and pricelist is going to be changed")
+                msj = _("You can not change partner if there are sale lines and pricelist is going to be changed")
             else:
                 msj = _(
                     "The change of the customer generates a  change in the"

--- a/price_security/models/sale_order.py
+++ b/price_security/models/sale_order.py
@@ -11,18 +11,22 @@ from odoo.exceptions import UserError
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.constrains("pricelist_id", "payment_term_id", "partner_id")
-    def check_priority(self):
-        if not self.env.user.has_group("price_security.group_only_view"):
-            return True
-        if (
-            self.partner_id.property_payment_term_id
-            and self.payment_term_id
-            and self.partner_id.property_payment_term_id.sequence < self.payment_term_id.sequence
-        ):
-            raise UserError(
-                _("Selected payment term priority can not be higher than payment term configured on partner")
-            )
+    @api.constrains("payment_term_id", "partner_id")
+    def check_allowed_payment_term(self):
+        for order in self:
+            if not self.env.user.has_group("price_security.group_only_view"):
+                continue
+
+            partner_payment_term = order.partner_id.property_payment_term_id
+            if not partner_payment_term or not order.payment_term_id:
+                continue
+
+            allowed = partner_payment_term.payment_term_allowed_ids
+
+            if order.payment_term_id not in allowed and order.payment_term_id != partner_payment_term:
+                raise UserError(
+                    _("You are not allowed to select this payment term according to the restrictions configured")
+                )
 
     @api.constrains("pricelist_id", "partner_id")
     def check_allowed_pricelist(self):
@@ -38,9 +42,7 @@ class SaleOrder(models.Model):
 
             if order.pricelist_id not in allowed and order.pricelist_id != partner_pricelist:
                 raise UserError(
-                    _(
-                        "You are not allowed to select this pricelist according to the restrictions configured on the partner"
-                    )
+                    _("You are not allowed to select this pricelist according to the restrictions configured")
                 )
 
     @api.onchange("partner_id")

--- a/price_security/views/account_payment_term_views.xml
+++ b/price_security/views/account_payment_term_views.xml
@@ -8,6 +8,9 @@
             <field name="name" position="after">
                 <field name="sequence" invisible="1"/>
             </field>
+            <xpath expr="//group/field[@name='company_id']" position="after">
+                <field name="payment_term_allowed_ids" widget="many2many_tags" domain="[('id', '!=', id)]"/>
+            </xpath>
         </field>
     </record>
     <record id="view_payment_term_tree" model="ir.ui.view">
@@ -17,6 +20,9 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="sequence" optional="hide"/>
+            </field>
+            <field name="name" position="after">
+                <field name="payment_term_allowed_ids" widget="many2many_tags"/>
             </field>
         </field>
     </record>

--- a/price_security/views/product_pricelist_views.xml
+++ b/price_security/views/product_pricelist_views.xml
@@ -8,6 +8,20 @@
             <field name="company_id" position="after">
                 <field name="sequence" optional="hide"/>
             </field>
+            <field name="country_group_ids" position="after">
+                <field name="pricelist_allowed_ids" widget="many2many_tags"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_pricelist_view" model="ir.ui.view">
+        <field name="name">product.pricelist.list</field>
+        <field name="model">product.pricelist</field>
+        <field name="inherit_id" ref="product.product_pricelist_view"/>
+        <field name="arch" type="xml">
+            <field name="country_group_ids" position="after">
+                <field name="pricelist_allowed_ids" widget="many2many_tags" domain="[('id', '!=', id)]"/>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Adds a new constraint on sale orders that limits pricelist selection for users in the "price restriction" group. Only allows selecting pricelists defined in the`pricelist_allowed_ids` field of the partner's pricelist, always allowing the partner's current pricelist.