### PR TITLE
[FIX] product_catalog_tree: clear context when updating order line info

### DIFF
--- a/product_catalog_tree/models/product_product.py
+++ b/product_catalog_tree/models/product_product.py
@@ -59,7 +59,10 @@ class ProductProduct(models.Model):
         order = self.env[res_model].browse(order_id)
         for rec in self:
             # Actualizar la información de la línea de orden
-            order.with_company(order.company_id)._update_order_line_info(rec.id, product_catalog_qty)
+            # Call the order method with a cleared context to avoid errors on creating move line
+            order.with_company(order.company_id).with_context(clear_context=True)._update_order_line_info(
+                rec.id, product_catalog_qty
+            )
 
     def increase_quantity(self):
         for rec in self:


### PR DESCRIPTION
When using catalog tree from invoices a context with UI keys is passed and that produces errors when creating account move lines. This commit clears the context when calling the order method to avoid such issues.