### PR TITLE
[IMP] product_catalog_tree, product_price_taxes_included, product_ux: show prices with taxes included and hide optional price fields

### DIFF
--- a/product_catalog_tree/__manifest__.py
+++ b/product_catalog_tree/__manifest__.py
@@ -29,6 +29,9 @@
     "images": [],
     "depends": [
         "product",
+        "stock",
+        "account",
+        "sale",
     ],
     "data": [
         "views/product_product_views.xml",

--- a/product_catalog_tree/models/product_product.py
+++ b/product_catalog_tree/models/product_product.py
@@ -3,9 +3,12 @@
 # directory
 ##############################################################################
 import json
+import logging
 
 from lxml import etree
 from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ProductProduct(models.Model):
@@ -20,6 +23,74 @@ class ProductProduct(models.Model):
         compute="_compute_catalog_values",
         readonly=True,
     )
+    product_catalog_supplier_uom = fields.Char(
+        string="Supplier UoM",
+        compute="_compute_catalog_supplier_uom",
+        readonly=True,
+    )
+    product_catalog_price_taxed = fields.Float(
+        string="Order Price with taxes",
+        compute="_compute_product_catalog_price_taxed",
+        readonly=True,
+    )
+
+    def _get_order_context_data(self):
+        res_model = self.env.context.get("product_catalog_order_model")
+        order_id = self.env.context.get("order_id")
+        if not res_model or not order_id:
+            return None
+        order = self.env[res_model].browse(order_id)
+        return order if order.exists() else None
+
+    def _compute_catalog_supplier_uom(self):
+        res_model = self.env.context.get("product_catalog_order_model")
+        order = self._get_order_context_data()
+
+        for rec in self:
+            rec.product_catalog_supplier_uom = ""
+            if res_model == "purchase.order" and order and order.partner_id:
+                seller = rec.seller_ids.filtered(lambda s: s.partner_id == order.partner_id)[:1]
+                if seller and seller.product_uom_id:
+                    rec.product_catalog_supplier_uom = seller.product_uom_id.name
+
+    @api.depends("product_tmpl_id.taxes_id", "product_catalog_price")
+    @api.depends_context("company", "company_id", "order_id", "product_catalog_order_model")
+    def _compute_product_catalog_price_taxed(self):
+        order = self._get_order_context_data()
+
+        for rec in self:
+            if not rec.product_catalog_price:
+                rec.product_catalog_price_taxed = 0.0
+                continue
+
+            currency = self.env.company.currency_id
+            partner = self.env["res.partner"]
+            company_id = self.env.context.get("company_id", self.env.company.id)
+            taxes = rec.taxes_id.filtered(lambda x: x.company_id.id == company_id)
+
+            if order:
+                currency = order.currency_id or currency
+                partner = order.partner_id
+                company_id = (order.company_id or self.env.company).id
+                taxes = rec.taxes_id.filtered(lambda x: x.company_id.id == company_id)
+                if order.fiscal_position_id:
+                    taxes = order.fiscal_position_id.map_tax(taxes)
+
+            if taxes:
+                try:
+                    tax_result = taxes.sudo().compute_all(
+                        rec.product_catalog_price, currency=currency, quantity=1.0, product=rec, partner=partner
+                    )
+                    rec.product_catalog_price_taxed = tax_result["total_included"]
+                except Exception:
+                    _logger.warning(
+                        "Failed to compute taxed price for product %s, falling back to base price",
+                        rec.id,
+                        exc_info=True,
+                    )
+                    rec.product_catalog_price_taxed = rec.product_catalog_price
+            else:
+                rec.product_catalog_price_taxed = rec.product_catalog_price
 
     def write(self, vals):
         """

--- a/product_catalog_tree/views/product_product_views.xml
+++ b/product_catalog_tree/views/product_product_views.xml
@@ -19,8 +19,29 @@
                 <button name="increase_quantity" type='object' icon='fa-plus' title='Add one'></button>
             </field>
             <field name="standard_price" position="after">
-                <field name="product_catalog_price"/>
+                <field name="product_catalog_price" optional="hide"/>
+                <field name="product_catalog_price_taxed" optional="show"/>
+                <field name="product_catalog_supplier_uom" optional="show" string="Supplier UoM"/>
             </field>
+        </field>
+    </record>
+
+    <record id="product_view_kanban_catalog" model="ir.ui.view">
+        <field name="name">product.view.kanban.catalog</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
+        <field name="arch" type="xml">
+            <!-- Agregar campos de precio del catálogo -->
+            <field name="id" position="after">
+                <field name="product_catalog_price"/>
+                <field name="product_catalog_price_taxed"/>
+            </field>
+            <!-- Agregar precio con impuestos después del div de precio -->
+            <div name="o_kanban_price" position="after">
+                <div class="text-muted small" t-if="record.product_catalog_price_taxed.raw_value">
+                    With taxes: <t t-out="record.product_catalog_price_taxed.raw_value"/>
+                </div>
+            </div>
         </field>
     </record>
 

--- a/product_price_taxes_included/views/product_product_views.xml
+++ b/product_price_taxes_included/views/product_product_views.xml
@@ -7,7 +7,11 @@
         <field name="inherit_id" ref="product.product_product_tree_view"></field>
         <field name="arch" type="xml">
             <field name="lst_price" position="after">
-                <field name="taxed_lst_price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                <field name="taxed_lst_price"
+       widget="monetary"
+       options="{'currency_field': 'currency_id'}"
+       optional="hide"/>
+
             </field>
         </field>
     </record>

--- a/product_ux/views/product_product_views.xml
+++ b/product_ux/views/product_product_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="product.product_product_tree_view"/>
         <field name="arch" type="xml">
             <field name="standard_price" position="after">
-                <field name="pricelist_price"/>
+                <field name="pricelist_price" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Changes

- [IMP] product_catalog_tree: add `product_catalog_price_taxed` computed field (price with taxes included applying fiscal position), add helper `_get_order_context_data()`, update catalog list view (`product_catalog_price` optional=hide) and kanban view
- [IMP] product_catalog_tree: add `product_catalog_supplier_uom` computed field showing supplier UoM in purchase order context
- [IMP] product_price_taxes_included: set `taxed_lst_price` as optional=hide by default
- [IMP] product_ux: set `pricelist_price` as optional=hide by default

## Related

Task: #63584
Branch: `19.0-t-63584-gal-v2`
