### PR TITLE
[IMP] product_currency: migrate demo to Python via _load_records

### DIFF
--- a/product_currency/__init__.py
+++ b/product_currency/__init__.py
@@ -2,4 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
+from . import models, demo

--- a/product_currency/__manifest__.py
+++ b/product_currency/__manifest__.py
@@ -34,9 +34,7 @@
         "views/product_template_views.xml",
         "security/product_currency_security.xml",
     ],
-    "demo": [
-        "demo/product_product_demo.xml",
-    ],
+    "demo": ["demo/product_product_demo.xml"],
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/product_currency/demo/__init__.py
+++ b/product_currency/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import product_currency_demo

--- a/product_currency/demo/product_currency_demo.py
+++ b/product_currency/demo/product_currency_demo.py
@@ -1,0 +1,53 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+# pylint: disable=consider-merging-classes-inherited
+# pylint: disable=R8180
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.model
+    def _install_product_currency_demo(self, companies=None):
+        if companies:
+            for company in companies:
+                _logger.info("Creating product_currency demo data for: %s", company.name)
+                env = self.with_context(allowed_company_ids=[company.id]).env
+                env[self._name]._load_records(self._product_currency_demo_records())
+            return
+        _logger.info("Creating product_currency demo data")
+        self._load_records(self._product_currency_demo_records())
+
+    @api.model
+    def _product_currency_demo_records(self):
+        usd_id = self.env.ref("base.USD").id
+        eur_id = self.env.ref("base.EUR").id
+        return [
+            {
+                "xml_id": "product_currency.demo_product_usd",
+                "values": {
+                    "name": "Product USD",
+                    "type": "service",
+                    "list_price": 100.0,
+                    "currency_id": usd_id,
+                    "force_currency_id": usd_id,
+                },
+                "noupdate": True,
+            },
+            {
+                "xml_id": "product_currency.product_with_forced_currency",
+                "values": {
+                    "name": "Product with forced currency (EUR)",
+                    "categ_id": self.env.ref("product.product_category_goods").id,
+                    "standard_price": 50.0,
+                    "list_price": 100.0,
+                    "currency_id": usd_id,
+                    "force_currency_id": eur_id,
+                    "type": "consu",
+                },
+                "noupdate": True,
+            },
+        ]

--- a/product_currency/demo/product_product_demo.xml
+++ b/product_currency/demo/product_product_demo.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
-    <record id="product_with_forced_currency" model="product.product">
-        <field name="name">Product with forced currency (EUR)</field>
-        <field name="categ_id" ref="product.product_category_goods"/>
-        <field name="standard_price">50</field>
-        <field name="list_price">100</field>
-        <field name="currency_id" ref="base.USD"/>
-        <field name="force_currency_id" ref="base.EUR"/>
-        <field name="type">consu</field>
-    </record>
+<odoo>
+    <function model="product.template" name="_install_product_currency_demo"/>
 </odoo>

--- a/product_currency/tests/__init__.py
+++ b/product_currency/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_currency_demo

--- a/product_currency/tests/test_product_currency_demo.py
+++ b/product_currency/tests/test_product_currency_demo.py
@@ -1,0 +1,28 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestProductCurrencyDemo(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env["product.template"]._install_product_currency_demo()
+        cls.demo_product_usd = cls.env.ref("product_currency.demo_product_usd")
+        cls.demo_product_eur = cls.env.ref("product_currency.product_with_forced_currency")
+
+    def test_demo_product_usd_exists(self):
+        self.assertTrue(self.demo_product_usd.force_currency_id)
+        self.assertEqual(self.demo_product_usd.force_currency_id, self.env.ref("base.USD"))
+
+    def test_demo_product_eur_force_currency(self):
+        self.assertEqual(self.demo_product_eur.force_currency_id, self.env.ref("base.EUR"))
+
+    def test_idempotent(self):
+        """Segunda llamada no duplica ni pisa registros (noupdate=True via _load_records)."""
+        self.env["product.template"]._install_product_currency_demo()
+        self.assertEqual(
+            self.env["ir.model.data"].search_count(
+                [("module", "=", "product_currency"), ("name", "=", "demo_product_usd")]
+            ),
+            1,
+        )


### PR DESCRIPTION
- Replace XML demo record with a Python function called via <function>
  in the demo manifest entry (native Odoo pattern)
- Use BaseModel._load_records instead of a custom _create_demo_record:
  respects noupdate=True, survives -u without clobbering, no reaping
- Add EUR demo product (product_with_forced_currency)
- Add tests: USD/EUR force_currency assertions + idempotency check