### PR TITLE
[ADD] product_catalog_tree_price_taxes_included, product_price_taxes_included, product_ux: show order price with taxes in catalog and hide extra price columns by default

### DIFF
--- a/product_catalog_tree_price_taxes_included/__init__.py
+++ b/product_catalog_tree_price_taxes_included/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/product_catalog_tree_price_taxes_included/__manifest__.py
+++ b/product_catalog_tree_price_taxes_included/__manifest__.py
@@ -1,0 +1,40 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Product Catalog Tree Price Taxes Included",
+    "version": "19.0.1.0.0",
+    "category": "Products",
+    "sequence": 14,
+    "summary": "Show order price with taxes included in the product catalog",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "product_catalog_tree",
+        "product_price_taxes_included",
+    ],
+    "data": [
+        "views/product_product_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/product_catalog_tree_price_taxes_included/models/__init__.py
+++ b/product_catalog_tree_price_taxes_included/models/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import product_product

--- a/product_catalog_tree_price_taxes_included/models/product_product.py
+++ b/product_catalog_tree_price_taxes_included/models/product_product.py
@@ -1,0 +1,51 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    product_catalog_price_taxed = fields.Float(
+        string="Order Price with Taxes",
+        compute="_compute_product_catalog_price_taxed",
+        readonly=True,
+    )
+
+    def _get_catalog_order(self):
+        """Return the order record from context, or None."""
+        res_model = self.env.context.get("product_catalog_order_model")
+        order_id = self.env.context.get("order_id")
+        if not res_model or not order_id:
+            return None
+        order = self.env[res_model].browse(order_id)
+        return order if order.exists() else None
+
+    @api.depends("product_tmpl_id.taxes_id")
+    @api.depends_context("company", "company_id", "order_id", "product_catalog_order_model")
+    def _compute_product_catalog_price_taxed(self):
+        order = self._get_catalog_order()
+        company_id = self.env.context.get("company_id", self.env.company.id)
+
+        for rec in self:
+            price = rec.product_catalog_price
+            if not price:
+                rec.product_catalog_price_taxed = 0.0
+                continue
+
+            currency = self.env.company.currency_id
+            partner = self.env["res.partner"]
+            taxes = rec.taxes_id.filtered(lambda x: x.company_id.id == company_id)
+
+            if order:
+                currency = order.currency_id or currency
+                partner = order.partner_id
+                company_id = (order.company_id or self.env.company).id
+                taxes = rec.taxes_id.filtered(lambda x: x.company_id.id == company_id)
+                if order.fiscal_position_id:
+                    taxes = order.fiscal_position_id.map_tax(taxes)
+
+            tax_result = taxes.sudo().compute_all(price, currency=currency, quantity=1.0, product=rec, partner=partner)
+            rec.product_catalog_price_taxed = tax_result["total_included"]

--- a/product_catalog_tree_price_taxes_included/views/product_product_views.xml
+++ b/product_catalog_tree_price_taxes_included/views/product_product_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_view_tree_catalog_price_taxed" model="ir.ui.view">
+        <field name="name">product.view.list.catalog.price.taxed</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product_catalog_tree.product_view_tree_catalog"/>
+        <field name="arch" type="xml">
+            <field name="product_catalog_price" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="product_catalog_price" position="after">
+                <field name="product_catalog_price_taxed" optional="show"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_view_kanban_catalog_price_taxed" model="ir.ui.view">
+        <field name="name">product.view.kanban.catalog.price.taxed</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
+        <field name="arch" type="xml">
+            <field name="id" position="after">
+                <field name="product_catalog_price_taxed"/>
+            </field>
+            <div name="o_kanban_price" position="after">
+                <div class="text-muted small" t-if="record.product_catalog_price_taxed.raw_value">
+                    With taxes: <t t-out="record.product_catalog_price_taxed.raw_value"/>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/product_price_taxes_included/views/product_product_views.xml
+++ b/product_price_taxes_included/views/product_product_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="product.product_product_tree_view"></field>
         <field name="arch" type="xml">
             <field name="lst_price" position="after">
-                <field name="taxed_lst_price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                <field name="taxed_lst_price" widget="monetary" options="{'currency_field': 'currency_id'}" optional="hide"/>
             </field>
         </field>
     </record>

--- a/product_ux/views/product_product_views.xml
+++ b/product_ux/views/product_product_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="product.product_product_tree_view"/>
         <field name="arch" type="xml">
             <field name="standard_price" position="after">
-                <field name="pricelist_price"/>
+                <field name="pricelist_price" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Changes

- [ADD] product_catalog_tree_price_taxes_included: show order price with taxes in product catalog
- [IMP] product_price_taxes_included: hide taxed_lst_price column by default in product list
- [IMP] product_ux: hide pricelist_price column by default in product list

## Related

Task: #63584
Branch: `19.0-t-63584-gal-v3`
