### PR TITLE
[FIX] product_replenishment_cost_stock: remove standard_price fallback

### DIFF
--- a/product_replenishment_cost_stock/models/purchase_order_line.py
+++ b/product_replenishment_cost_stock/models/purchase_order_line.py
@@ -14,7 +14,4 @@ class PurchaseOrderLine(models.Model):
         vals = super()._prepare_purchase_order_line_from_procurement(
             product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, po
         )
-        if vals["price_unit"] == 0:
-            vals["price_unit"] = product_id.standard_price
-
         return vals

--- a/product_replenishment_cost_stock/models/stock_rule.py
+++ b/product_replenishment_cost_stock/models/stock_rule.py
@@ -23,7 +23,4 @@ class StockRule(models.Model):
                 price_unit, po.currency_id, po.company_id, po.date_order or fields.Date.today()
             )
         vals["price_unit"] = price_unit
-        if vals["price_unit"] == 0:
-            vals["price_unit"] = product_id.standard_price
-
         return vals


### PR DESCRIPTION
## Problem

When `price_unit` resolved to 0 during procurement/replenishment flows, `product_replenishment_cost_stock` was falling back to `product_id.standard_price`. With `product_replenishment_cost` installed, the replenishment-cost cron overwrites `standard_price` with the replenishment cost (often expressed in a different currency, e.g. ARS), producing wrong prices in purchase orders instead of 0 or the correct supplier net price.

Affected methods:
- `_prepare_purchase_order_line_from_procurement` in `product_replenishment_cost_stock/purchase_order_line.py`
- `_update_purchase_order_line` in `product_replenishment_cost_stock/stock_rule.py`

## Fix

Remove both `standard_price` fallbacks. When `net_price` is 0 or unavailable, the price stays 0 and the caller handles it explicitly — no silent corruption from the replenishment cost value.

## Notes

- Backport/adaptation of #892 (19.0) to 18.0.
- Related task: T-67503 / ticket #115433 (bo-neored client).