### PR TITLE
[FIX] product_replenishment_cost: skip currency convert when same currency in compute

### DIFF
--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Replenishment Cost",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Products",

--- a/product_replenishment_cost/models/purchase_order_line.py
+++ b/product_replenishment_cost/models/purchase_order_line.py
@@ -33,9 +33,10 @@ class PurchaseOrderLine(models.Model):
                 if seller
                 else 0.0
             )
-            price_unit = seller.currency_id._convert(
-                price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.today()
-            )
+            if seller.currency_id and line.currency_id and seller.currency_id != line.currency_id:
+                price_unit = seller.currency_id._convert(
+                    price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.today()
+                )
 
             if seller and line.product_uom and seller.product_uom != line.product_uom:
                 price_unit = seller.product_uom._compute_price(price_unit, line.product_uom)


### PR DESCRIPTION
## Problem

`_compute_price_unit_and_date_planned_and_name` calls `seller.currency_id._convert()` unconditionally. When the seller currency and the line currency are the same (e.g. both USD), `_convert` still applies the currency's rounding precision. For very small prices below that precision (e.g. `0.0046 USD` rounded to 2 decimals → `0.00`), the computed `price_unit` becomes 0 on manually added PO lines.

This does not affect replenishment (`_prepare_purchase_order_line`), which already has the guard:
```python
if supplier.currency_id != po.currency_id:
    price_unit = supplier.currency_id._convert(...)
```

## Fix

Apply the same guard in `_compute_price_unit_and_date_planned_and_name`: only call `_convert` when the currencies differ.

## Related PRs

Works together with:
- ingadhoc/product#904 — removes `standard_price` fallbacks in `product_replenishment_cost_stock`
- ingadhoc/purchase#336 — removes `standard_price` fallback in `purchase_ux`