### PR TITLE
[ADD] stock_account_cost_revaluation: revaluation entry on cost change for real_time (standard/AVCO)

### DIFF
--- a/stock_account_cost_revaluation/README.rst
+++ b/stock_account_cost_revaluation/README.rst
@@ -1,0 +1,94 @@
+=======================================
+Stock Account - Cost Change Revaluation
+=======================================
+
+Postea el asiento de revaluación de inventario al cambiar el costo contable
+(``standard_price``) de productos con categoría de valoración perpetua
+(``real_time``), en costeo estándar o promedio (AVCO).
+
+Características
+===============
+
+- Al cambiar el costo contable (``standard_price``) de un producto con
+  **categoría de valoración perpetua** (``real_time``) y costeo **estándar** o
+  **promedio (AVCO)**, genera automáticamente el asiento de revaluación de
+  inventario por la diferencia sobre el stock on hand:
+  ``qty_on_hand × (costo_nuevo − costo_viejo)``.
+- Aplica a cualquier origen del cambio de costo, ya que engancha en el punto
+  común de todo cambio de ``standard_price``: edición manual del costo en la
+  ficha, actualización desde el costo de reposición (módulo
+  ``product_replenishment_cost`` cuando está instalado, incluida la diferencia
+  de tipo de cambio con costo en moneda secundaria), importaciones, etc.
+- El signo del asiento (Debe/Haber) lo maneja la misma lógica del cierre de
+  inventario nativo (``res.company._prepare_inventory_aml_vals``).
+- **Contrapartida = la cuenta de revaluación de inventario de la categoría**
+  (``property_cost_revaluation_account_id``, campo nuevo "Cost Revaluation
+  Account"), que es la cuenta de resultado de la revaluación. Si esa cuenta **no
+  está configurada, no se postea** el asiento (misma lógica que el core con la
+  cuenta de una ubicación de scrap/ajuste: sin cuenta, sin asiento). No se usa la
+  cuenta de variación de stock (pertenece al cierre continental) ni la de
+  diferencia de precio (se usa para la diferencia de precio de compras / PPV).
+- **No** genera asiento (por diseño): productos con costeo FIFO
+  (``standard_price`` es informativo), categorías con valoración periódica (lo
+  materializa el cierre de inventario), productos sin stock on hand y categorías
+  sin cuenta de revaluación.
+
+Detalles Técnicos
+=================
+
+- Modelos heredados:
+
+  - ``product.product``: override de ``_change_standard_price`` y método
+    ``_create_cost_revaluation_entry`` que arma y postea el ``account.move`` de
+    revaluación.
+  - ``product.category``: campo nuevo ``property_cost_revaluation_account_id``
+    ("Cost Revaluation Account"), Many2one a ``account.account``,
+    company-dependent.
+
+- Vistas incluidas:
+
+  - ``view_category_property_form``: hereda
+    ``stock_account.view_category_property_form`` y agrega el campo
+    ``property_cost_revaluation_account_id`` en el formulario de categoría de
+    producto (visible solo para valoración ``real_time`` y costeo
+    ``standard``/``average``).
+
+Uso
+===
+
+1. En la **categoría de producto**, configurar método de costeo *Estándar* o
+   *Promedio (AVCO)* y valoración de inventario *Automática (perpetua)*, junto
+   con las cuentas y el diario de stock (como toda valoración automática).
+2. Definir la **Cuenta de revaluación de inventario** ("Cost Revaluation Account")
+   en la categoría (es la cuenta de resultado de la revaluación). Si no se define,
+   el módulo no postea el asiento.
+3. Al cambiar el costo contable de un producto con stock — manualmente en la
+   ficha o por la actualización desde el costo de reposición — el módulo postea
+   automáticamente el asiento de revaluación por la diferencia.
+
+Arquitectura
+============
+
+La lógica se engancha en ``product.product._change_standard_price``, el punto
+por el que pasa todo cambio de ``standard_price`` en Odoo. Tras el
+comportamiento estándar, para los productos elegibles (categoría ``real_time``,
+costeo estándar o promedio, almacenable y con stock on hand) se calcula la
+diferencia de valuación y se postea el asiento entre la cuenta de valuación y la
+**cuenta de revaluación de inventario** de la categoría. Si esa cuenta de
+resultado no está configurada no se genera asiento, igual que el core no valoriza
+un movimiento hacia una ubicación sin cuenta de valuación.
+
+Dependencias
+============
+
+- ``stock_account``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/stock_account_cost_revaluation/__init__.py
+++ b/stock_account_cost_revaluation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_account_cost_revaluation/__manifest__.py
+++ b/stock_account_cost_revaluation/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Stock Account - Cost Change Revaluation",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "license": "AGPL-3",
+    "category": "Inventory/Accounting",
+    "summary": "Postea el asiento de revaluación de inventario al cambiar el costo "
+    "contable (standard_price) de productos con categoría de valoración perpetua "
+    "(real_time), en costeo estándar o promedio (AVCO).",
+    "depends": [
+        "stock_account",
+    ],
+    "data": [
+        "views/product_category_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/stock_account_cost_revaluation/models/__init__.py
+++ b/stock_account_cost_revaluation/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_category
+from . import product_product

--- a/stock_account_cost_revaluation/models/product_category.py
+++ b/stock_account_cost_revaluation/models/product_category.py
@@ -1,0 +1,20 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = "product.category"
+
+    property_cost_revaluation_account_id = fields.Many2one(
+        "account.account",
+        string="Cost Revaluation Account",
+        company_dependent=True,
+        ondelete="restrict",
+        check_company=True,
+        help="Cuenta de resultado (contrapartida) del asiento de revaluación de inventario "
+        "que se genera al cambiar el costo contable (standard_price) de productos con "
+        "valoración perpetua. Si no se define, no se genera el asiento.",
+    )

--- a/stock_account_cost_revaluation/models/product_product.py
+++ b/stock_account_cost_revaluation/models/product_product.py
@@ -1,0 +1,122 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import logging
+
+from odoo import Command, _, models
+from odoo.tools import float_compare, float_is_zero
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _change_standard_price(self, old_price):
+        """En v19 cambiar ``standard_price`` ya no genera el asiento de revaluación
+        de inventario: el core solo registra un ``product.value`` (línea de tiempo
+        del costo) y delega el impacto contable al cierre de inventario
+        (``action_close_stock_valuation``).
+
+        El problema es que el cron de cierre (``_cron_post_stock_valuation``)
+        **excluye explícitamente** las compañías con valoración perpetua
+        (``real_time``), por lo que para esos productos la revaluación por un
+        cambio de costo nunca se materializa sola.
+
+        Acá cubrimos ese hueco: tras el comportamiento estándar, posteamos el
+        asiento de revaluación para los productos cuya **categoría tiene valoración
+        ``real_time``**. Como es el chokepoint de todo cambio de ``standard_price``,
+        aplica a cualquier origen del ajuste (edición manual del costo contable,
+        cron de costo de reposición, importaciones, etc.).
+        """
+        res = super()._change_standard_price(old_price)
+        for product in self:
+            if product not in old_price:
+                continue
+            product._create_cost_revaluation_entry(old_price[product])
+        return res
+
+    def _create_cost_revaluation_entry(self, old_price):
+        """Contabiliza la diferencia de valuación de inventario por el cambio de
+        ``standard_price`` (costo nuevo vs. previo) sobre el stock on hand.
+
+        Solo aplica a productos con categoría de valoración perpetua
+        (``real_time``) y costeo **estándar o promedio (AVCO)**: en ambos el cambio
+        de ``standard_price`` revalúa el stock on hand (en AVCO el core lo usa como
+        ancla de revaluación, ver ``_run_average_batch``). **FIFO queda excluido**:
+        ahí ``standard_price`` es informativo y el core ni siquiera registra el
+        ``product.value`` — su revaluación se hace ajustando el valor del
+        movimiento/capa, que es otro mecanismo.
+
+        La contrapartida es la **cuenta de revaluación de inventario** configurada
+        en la categoría (``property_cost_revaluation_account_id``), que es la cuenta
+        de resultado de la revaluación. Igual que el core con el
+        ``valuation_account_id`` de una ubicación de scrap/ajuste: si no está
+        configurada, **no se postea** el asiento. El signo lo maneja
+        ``res.company._prepare_inventory_aml_vals``.
+        """
+        self.ensure_one()
+        company = self.env.company
+
+        # ``valuation`` se resuelve desde categ_id.property_valuation (con fallback
+        # a la compañía); gateamos en real_time para excluir las periódicas.
+        if self.valuation != "real_time" or self.cost_method not in ("standard", "average"):
+            return self.env["account.move"]
+        if not self.is_storable:
+            return self.env["account.move"]
+
+        prec = self.env["decimal.precision"].precision_get("Product Price")
+        new_price = self.standard_price
+        if float_compare(new_price, old_price, precision_digits=prec) == 0:
+            return self.env["account.move"]
+
+        # cantidad valorizada on hand (en la compañía actual)
+        quantity = self.qty_available
+        if float_is_zero(quantity, precision_rounding=self.uom_id.rounding):
+            return self.env["account.move"]
+
+        # delta > 0 (sube el costo) => aumenta el activo de inventario
+        delta_value = company.currency_id.round(quantity * (new_price - old_price))
+        if company.currency_id.is_zero(delta_value):
+            return self.env["account.move"]
+
+        accounts = self.product_tmpl_id.get_product_accounts()
+        valuation_account = accounts.get("stock_valuation")
+        journal = accounts.get("stock_journal")
+        # Contrapartida = cuenta de revaluación de inventario configurada en la
+        # categoría (cuenta de resultado). Misma lógica que el core con la cuenta de
+        # una ubicación de scrap/ajuste: si no está configurada, no se postea.
+        counterpart_account = self.categ_id.property_cost_revaluation_account_id
+        if not counterpart_account:
+            return self.env["account.move"]
+        if not (valuation_account and journal):
+            _logger.warning(
+                "No se pudo contabilizar la revaluación del producto %s: falta la cuenta de "
+                "valuación o el diario de stock.",
+                self.display_name,
+            )
+            return self.env["account.move"]
+
+        ref = _("Revaluación de costo: %s", self.display_name)
+        # Debe cuenta de valuación / Haber cuenta de revaluación (el signo
+        # según el delta lo maneja _prepare_inventory_aml_vals).
+        line_vals = company._prepare_inventory_aml_vals(
+            valuation_account, counterpart_account, delta_value, ref, product_id=self.id
+        )
+
+        move = (
+            self.env["account.move"]
+            .sudo()
+            .create(
+                {
+                    "journal_id": journal.id,
+                    "company_id": company.id,
+                    "ref": ref,
+                    "move_type": "entry",
+                    "line_ids": [Command.create(vals) for vals in line_vals],
+                }
+            )
+        )
+        move._post()
+        return move

--- a/stock_account_cost_revaluation/tests/__init__.py
+++ b/stock_account_cost_revaluation/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cost_revaluation

--- a/stock_account_cost_revaluation/tests/test_cost_revaluation.py
+++ b/stock_account_cost_revaluation/tests/test_cost_revaluation.py
@@ -1,0 +1,162 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestCostRevaluation(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+
+        # cuenta de valuación (activo), cuenta de revaluación (resultado) y diario
+        cls.acc_valuation = cls.env["account.account"].create(
+            {"name": "Stock Valuation", "code": "REVVAL", "account_type": "asset_current"}
+        )
+        cls.acc_cost_reval = cls.env["account.account"].create(
+            {"name": "Cost Revaluation", "code": "REVCRA", "account_type": "expense"}
+        )
+        cls.stock_journal = cls.env["account.journal"].create(
+            {"name": "Stock Journal REV", "code": "REVSJ", "type": "general", "company_id": cls.company.id}
+        )
+        cls.company.account_stock_journal_id = cls.stock_journal
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+
+    # ------------------------------------------------------------------ helpers
+    def _categ(self, cost_method, valuation, revaluation_account=True):
+        vals = {
+            "name": "Categ %s %s" % (cost_method, valuation),
+            "property_cost_method": cost_method,
+            "property_valuation": valuation,
+            "property_stock_valuation_account_id": self.acc_valuation.id,
+            "property_stock_journal": self.stock_journal.id,
+        }
+        if revaluation_account:
+            vals["property_cost_revaluation_account_id"] = self.acc_cost_reval.id
+        return self.env["product.category"].create(vals)
+
+    def _product(self, categ, price=10.0, qty=10.0):
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto %s" % categ.name,
+                "type": "consu",
+                "is_storable": True,
+                "categ_id": categ.id,
+                "standard_price": price,
+            }
+        )
+        # stock recién después de fijar el costo inicial (sin stock no postea)
+        self.env["stock.quant"]._update_available_quantity(product, self.stock_location, qty)
+        # qty_available es computado no-almacenado y su depends no incluye los quants:
+        # invalidamos para que el siguiente acceso lo recalcule desde el quant creado.
+        product.invalidate_recordset()
+        self.assertEqual(product.qty_available, qty, "El stock on hand de prueba no quedó registrado")
+        return product
+
+    def _journal_moves_count(self):
+        return self.env["account.move"].search_count([("journal_id", "=", self.stock_journal.id)])
+
+    # -------------------------------------------------------------------- tests
+    def test_revaluation_standard_realtime(self):
+        product = self._product(self._categ("standard", "real_time"))
+        before = self._journal_moves_count()
+        # 10 -> 15 con 10 unidades => delta 50 (sube el activo)
+        product.standard_price = 15.0
+        moves = self.env["account.move"].search([("journal_id", "=", self.stock_journal.id)])
+        self.assertEqual(len(moves) - before, 1, "Standard real_time debe generar asiento")
+        move = moves.sorted("id")[-1]
+        self.assertEqual(move.state, "posted")
+        # Debe Valuación / Haber Diferencia de precio
+        self.assertAlmostEqual(move.line_ids.filtered(lambda l: l.account_id == self.acc_valuation).debit, 50.0, 2)
+        self.assertAlmostEqual(move.line_ids.filtered(lambda l: l.account_id == self.acc_cost_reval).credit, 50.0, 2)
+
+    def test_revaluation_average_realtime(self):
+        # AVCO: el cambio de standard_price también es una revaluación
+        product = self._product(self._categ("average", "real_time"))
+        self.assertEqual(product.cost_method, "average")
+        before = self._journal_moves_count()
+        # 10 -> 8 con 10 unidades => delta -20 (baja el activo)
+        product.standard_price = 8.0
+        moves = self.env["account.move"].search([("journal_id", "=", self.stock_journal.id)])
+        self.assertEqual(len(moves) - before, 1, "AVCO real_time debe generar asiento")
+        move = moves.sorted("id")[-1]
+        self.assertEqual(move.state, "posted")
+        # costo bajó => Haber Valuación / Debe Diferencia de precio
+        self.assertAlmostEqual(move.line_ids.filtered(lambda l: l.account_id == self.acc_valuation).credit, 20.0, 2)
+        self.assertAlmostEqual(move.line_ids.filtered(lambda l: l.account_id == self.acc_cost_reval).debit, 20.0, 2)
+
+    def test_no_entry_without_revaluation_account(self):
+        # sin cuenta de revaluación configurada => no se postea (lógica scrap)
+        product = self._product(self._categ("standard", "real_time", revaluation_account=False))
+        before = self._journal_moves_count()
+        product.standard_price = 15.0
+        self.assertEqual(
+            self._journal_moves_count(),
+            before,
+            "Sin cuenta de revaluación no debe generar asiento",
+        )
+
+    def _pending_variation(self, product):
+        # diferencia que el reporte/cierre de Valoración de inventario sugeriría postear
+        # sobre la cuenta de valuación: valuación teórica (total_value) vs. saldo contable.
+        company = self.company
+        accounts_by_product = company._get_accounts_by_product(products=product)
+        inventory = company.stock_value(accounts_by_product)
+        accounting = company.stock_accounting_value(accounts_by_product)
+        return {acc: inventory.get(acc, 0.0) - accounting.get(acc, 0.0) for acc in inventory.keys() | accounting.keys()}
+
+    def test_no_suggested_entry_on_valuation_account(self):
+        # nuestro asiento mueve la cuenta de valuación en la misma magnitud que el costo,
+        # así que la variación pendiente sobre la cuenta de valuación queda igual que antes
+        # (no aparece variación nueva en esa pata del cierre/reporte).
+        product = self._product(self._categ("standard", "real_time"))  # costo 10, qty 10
+        pending_before = self._pending_variation(product)
+
+        product.standard_price = 15.0  # +50 sobre la cuenta de valuación
+
+        pending_after = self._pending_variation(product)
+        for acc in set(pending_before) | set(pending_after):
+            delta = pending_after.get(acc, 0.0) - pending_before.get(acc, 0.0)
+            self.assertTrue(
+                self.company.currency_id.is_zero(delta),
+                "El cambio de costo no debe agregar variación pendiente en %s (delta %s)" % (acc.code, delta),
+            )
+
+    def test_no_entry_fifo_realtime(self):
+        # FIFO: standard_price es informativo, no revalúa => sin asiento
+        product = self._product(self._categ("fifo", "real_time"))
+        self.assertEqual(product.cost_method, "fifo")
+        before = self._journal_moves_count()
+        product.standard_price = 20.0
+        self.assertEqual(
+            self._journal_moves_count(), before, "FIFO no debe generar asiento por cambio de standard_price"
+        )
+
+    def test_no_entry_periodic_category(self):
+        # categoría periódica => el ajuste lo materializa el cierre, no este flujo
+        product = self._product(self._categ("standard", "periodic"))
+        self.assertEqual(product.valuation, "periodic")
+        before = self._journal_moves_count()
+        product.standard_price = 15.0
+        self.assertEqual(self._journal_moves_count(), before, "Categoría periódica no debe generar asiento")
+
+    def test_no_entry_without_stock(self):
+        # sin stock on hand no debe generarse asiento aunque cambie el costo
+        categ = self._categ("standard", "real_time")
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto Sin Stock",
+                "type": "consu",
+                "is_storable": True,
+                "categ_id": categ.id,
+                "standard_price": 10.0,
+            }
+        )
+        before = self._journal_moves_count()
+        product.standard_price = 15.0
+        self.assertEqual(self._journal_moves_count(), before, "Sin stock on hand no debe generar asiento")

--- a/stock_account_cost_revaluation/views/product_category_views.xml
+++ b/stock_account_cost_revaluation/views/product_category_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_category_property_form" model="ir.ui.view">
+        <field name="name">product.category.cost.revaluation.form.inherit</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock_account.view_category_property_form"/>
+        <field name="arch" type="xml">
+            <field name="property_stock_valuation_account_id" position="after">
+                <field name="property_cost_revaluation_account_id"
+                       options="{'no_create': True}"
+                       invisible="property_valuation != 'real_time' or property_cost_method not in ['standard', 'average']"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Qué

Nuevo módulo `stock_account_cost_revaluation` (depends: `stock_account`) que
postea el asiento de revaluación de inventario cuando cambia el costo contable
(`standard_price`) de un producto con categoría de valoración perpetua
(`real_time`), en costeo **estándar** o **promedio (AVCO)**.

## Por qué

En 19.0 el cambio de `standard_price` ya no genera el asiento de revaluación: el
core solo registra un `product.value` y delega el impacto contable al cierre de
inventario (`action_close_stock_valuation`). Pero el cron de cierre
(`_cron_post_stock_valuation`) **excluye explícitamente** las compañías con
valoración `real_time`, así que para esos productos la revaluación por un cambio
de costo nunca se materializa (regresión vs 18.0, que la posteaba automáticamente).

## Cómo

- Hook en `product.product._change_standard_price` (chokepoint de todo cambio de
  costo) → cubre la edición manual del costo contable, la actualización desde el
  costo de reposición (`product_replenishment_cost`, cuando está instalado),
  importaciones, etc.
- Gating: `valuation == 'real_time'` + costeo `standard` o `average` + producto
  almacenable + stock on hand > 0.
- **FIFO excluido**: ahí `standard_price` es informativo y el core ni registra el
  `product.value`; su revaluación se hace ajustando el valor del movimiento/capa
  (mecanismo aparte, fuera del alcance de este PR).
- Las categorías periódicas quedan excluidas (las cubre el cierre).
- El asiento usa la misma lógica de cuentas y signo que el cierre nativo
  (`res.company._prepare_inventory_aml_vals`): cuenta de valuación contra la
  contrapartida, por `qty_on_hand × (costo_nuevo − costo_viejo)`. Idempotente con
  un cierre posterior.
- **Cuenta de contrapartida parametrizable por categoría de producto**
  (`property_cost_revaluation_account_id`). Si no se define, fallback a la cuenta
  de variación de stock y, en su defecto, a la cuenta de gasto de la compañía
  (mismo fallback que el cierre nativo).

## Test plan

`stock_account_cost_revaluation/tests/test_cost_revaluation.py`:

- `test_revaluation_standard_realtime`: standard + real_time → asiento por la diferencia.
- `test_revaluation_average_realtime`: AVCO + real_time → asiento por la diferencia.
- `test_revaluation_uses_category_account`: usa la cuenta de contrapartida definida en la categoría.
- `test_no_entry_fifo_realtime`: FIFO → sin asiento.
- `test_no_entry_periodic_category`: categoría periódica → sin asiento.
- `test_no_entry_without_stock`: sin stock on hand → sin asiento.
