### PR TITLE
[ADD] product_secondary_unit_ux: show secondary unit factor with more decimals

### DIFF
--- a/product_secondary_unit_ux/README.rst
+++ b/product_secondary_unit_ux/README.rst
@@ -1,0 +1,77 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================
+Product Secondary Unit UX
+=========================
+
+Usability improvements for the OCA module "Product Secondary Unit":
+
+#. Display the secondary unit "Factor" field with 6 decimals instead of the
+   default 2 decimals, so the user sees the real precision stored and used in
+   the conversions (e.g. ``0.444444`` instead of ``0.44``). This is a
+   display-only change: it does not modify how the value is stored or rounded.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Just install this module.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. No configuration needed.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Enable the "Units of Measure" feature (group ``uom.group_uom``).
+#. Open a product and, under the "Secondary Unit of Measure" section, add a
+   secondary unit. The "Factor" field is shown with 6 decimals.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/product/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/product_secondary_unit_ux/__manifest__.py
+++ b/product_secondary_unit_ux/__manifest__.py
@@ -1,0 +1,39 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Product Secondary Unit UX",
+    "version": "18.0.1.0.0",
+    "category": "Products",
+    "sequence": 14,
+    "summary": "",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "product_secondary_unit",
+    ],
+    "data": [
+        "views/product_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/product_secondary_unit_ux/views/product_views.xml
+++ b/product_secondary_unit_ux/views/product_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.secondary.unit.factor.digits</field>
+        <field name="model">product.template</field>
+        <field
+            name="inherit_id"
+            ref="product_secondary_unit.product_template_form_view"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='secondary_uom_ids']/list/field[@name='factor']"
+                position="attributes"
+            >
+                <attribute name="digits">[16, 6]</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## What

New UX module `product_secondary_unit_ux` that improves how the secondary unit conversion factor is displayed.

## Why

The OCA `product_secondary_unit` "Factor" field (`product.secondary.unit.factor`) is declared as a plain `Float` with no `digits`. As a result the web client renders it with only 2 decimals, while the value is stored and used in conversions with full precision. Users would see e.g. `0.44` and not realize the effective value carried more precision, leading to apparent conversion mismatches.

## How

A single view inherits `product_secondary_unit.product_template_form_view` and sets `digits="[16, 6]"` on the `factor` field via `position="attributes"`. This is **display-only**: it does not change storage or rounding, so calculation behavior is unchanged.

## Test plan

1. Install the module (auto-installs when `product_secondary_unit` is present).
2. Enable Units of Measure (`uom.group_uom`).
3. On a product, add a secondary unit and set a factor with more than 2 decimals.
4. The factor field shows 6 decimals (both on product template and variant forms), reflecting the real stored value.

Task: https://www.adhoc.inc/odoo/project.task/69157
