### PR TITLE
[IMP] product_catalog_tree: add button to load vendor min qty in list catalog

### DIFF
--- a/product_catalog_tree/__manifest__.py
+++ b/product_catalog_tree/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Product Catalog Tree",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Products",
     "sequence": 14,
     "summary": "",

--- a/product_catalog_tree/models/product_product.py
+++ b/product_catalog_tree/models/product_product.py
@@ -20,6 +20,11 @@ class ProductProduct(models.Model):
         compute="_compute_catalog_values",
         readonly=True,
     )
+    product_catalog_min_qty = fields.Float(
+        string="Supplier Min Qty",
+        compute="_compute_catalog_values",
+        readonly=True,
+    )
 
     def write(self, vals):
         """
@@ -39,6 +44,7 @@ class ProductProduct(models.Model):
         if not res_model or not order_id:
             self.product_catalog_qty = 0
             self.product_catalog_price = 0
+            self.product_catalog_min_qty = 0
             return
 
         order = self.env[res_model].browse(order_id)
@@ -48,6 +54,7 @@ class ProductProduct(models.Model):
         for rec in self:
             rec.product_catalog_qty = order_line_info[rec.id].get("quantity")
             rec.product_catalog_price = order_line_info[rec.id].get("price")
+            rec.product_catalog_min_qty = order_line_info[rec.id].get("min_qty", 0)
 
     def _inverse_catalog_values(self, product_catalog_qty):
         res_model = self._context.get("product_catalog_order_model")
@@ -84,6 +91,22 @@ class ProductProduct(models.Model):
     def increase_quantity(self):
         for rec in self:
             rec._inverse_catalog_values(rec.product_catalog_qty + 1)
+
+    def add_catalog_min_qty(self):
+        """Add the product using the vendor's minimum quantity.
+
+        Mirrors the kanban catalog behaviour (see purchase
+        ``product_catalog/kanban_record.js`` ``addProduct``): when the product is
+        not on the order yet and the vendor defines a minimum quantity, add it
+        with that ``min_qty`` so the vendor pricelist price applies instead of
+        falling back to the product cost. If the product is already on the order
+        it just adds one, like the ``+`` button.
+        """
+        for rec in self:
+            if not rec.product_catalog_qty and rec.product_catalog_min_qty:
+                rec._inverse_catalog_values(rec.product_catalog_min_qty)
+            else:
+                rec._inverse_catalog_values(rec.product_catalog_qty + 1)
 
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):

--- a/product_catalog_tree/models/product_product.py
+++ b/product_catalog_tree/models/product_product.py
@@ -92,21 +92,20 @@ class ProductProduct(models.Model):
         for rec in self:
             rec._inverse_catalog_values(rec.product_catalog_qty + 1)
 
-    def add_catalog_min_qty(self):
-        """Add the product using the vendor's minimum quantity.
+    def set_catalog_min_qty(self):
+        """Set the order quantity to the vendor's minimum quantity.
 
-        Mirrors the kanban catalog behaviour (see purchase
-        ``product_catalog/kanban_record.js`` ``addProduct``): when the product is
-        not on the order yet and the vendor defines a minimum quantity, add it
-        with that ``min_qty`` so the vendor pricelist price applies instead of
-        falling back to the product cost. If the product is already on the order
-        it just adds one, like the ``+`` button.
+        The list catalog ``+`` button (:meth:`increase_quantity`) always adds
+        one unit, so a line can stay below the vendor ``min_qty`` and fall back
+        to the product cost instead of the vendor pricelist price. This
+        dedicated button always sets the quantity to the vendor ``min_qty`` --
+        whether the product is already on the order or not -- so the vendor
+        price applies. The button is only shown when the vendor defines a
+        ``min_qty`` greater than 1.
         """
         for rec in self:
-            if not rec.product_catalog_qty and rec.product_catalog_min_qty:
+            if rec.product_catalog_min_qty:
                 rec._inverse_catalog_values(rec.product_catalog_min_qty)
-            else:
-                rec._inverse_catalog_values(rec.product_catalog_qty + 1)
 
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):

--- a/product_catalog_tree/tests/__init__.py
+++ b/product_catalog_tree/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_product_catalog_tree

--- a/product_catalog_tree/tests/test_product_catalog_tree.py
+++ b/product_catalog_tree/tests/test_product_catalog_tree.py
@@ -1,0 +1,69 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestProductCatalogTree(TransactionCase):
+    def test_add_catalog_min_qty_uses_supplier_price(self):
+        """The new catalog button adds the product with the vendor's min_qty,
+        so the supplier price applies instead of falling back to the cost."""
+        if "purchase.order" not in self.env:
+            self.skipTest("purchase is not installed")
+
+        vendor = self.env["res.partner"].create({"name": "Vendor Min Qty"})
+        product = self.env["product.product"].create({
+            "name": "Cable roll 100m",
+            "standard_price": 50.0,
+            "purchase_ok": True,
+            "seller_ids": [(0, 0, {
+                "partner_id": vendor.id,
+                "price": 99.0,
+                "min_qty": 100,
+            })],
+        })
+        order = self.env["purchase.order"].create({"partner_id": vendor.id})
+        catalog_product = product.with_context(
+            product_catalog_order_model="purchase.order",
+            order_id=order.id,
+        )
+
+        # the vendor minimum quantity is exposed on the catalog row
+        self.assertEqual(catalog_product.product_catalog_min_qty, 100)
+
+        # the new button adds the product with the vendor min_qty (mirrors the
+        # kanban catalog) instead of a hardcoded 1 like the ``+`` button
+        catalog_product.add_catalog_min_qty()
+        line = order.order_line.filtered(lambda line: line.product_id == product)
+        self.assertEqual(line.product_qty, 100)
+
+        # therefore the vendor price applies, not the product cost (50)
+        self.assertEqual(line.price_unit, 99.0)
+
+    def test_increase_quantity_keeps_adding_one(self):
+        """The ``+`` button keeps its original behaviour (adds one)."""
+        if "purchase.order" not in self.env:
+            self.skipTest("purchase is not installed")
+
+        vendor = self.env["res.partner"].create({"name": "Vendor Plus"})
+        product = self.env["product.product"].create({
+            "name": "Cable roll plus",
+            "standard_price": 50.0,
+            "purchase_ok": True,
+            "seller_ids": [(0, 0, {
+                "partner_id": vendor.id,
+                "price": 99.0,
+                "min_qty": 100,
+            })],
+        })
+        order = self.env["purchase.order"].create({"partner_id": vendor.id})
+        catalog_product = product.with_context(
+            product_catalog_order_model="purchase.order",
+            order_id=order.id,
+        )
+
+        catalog_product.increase_quantity()
+        line = order.order_line.filtered(lambda line: line.product_id == product)
+        self.assertEqual(line.product_qty, 1)

--- a/product_catalog_tree/tests/test_product_catalog_tree.py
+++ b/product_catalog_tree/tests/test_product_catalog_tree.py
@@ -7,23 +7,31 @@ from odoo.tests import TransactionCase, tagged
 
 @tagged("post_install", "-at_install")
 class TestProductCatalogTree(TransactionCase):
-    def test_add_catalog_min_qty_uses_supplier_price(self):
-        """The new catalog button adds the product with the vendor's min_qty,
+    def test_set_catalog_min_qty_uses_supplier_price(self):
+        """The new catalog button sets the product to the vendor's min_qty,
         so the supplier price applies instead of falling back to the cost."""
         if "purchase.order" not in self.env:
             self.skipTest("purchase is not installed")
 
         vendor = self.env["res.partner"].create({"name": "Vendor Min Qty"})
-        product = self.env["product.product"].create({
-            "name": "Cable roll 100m",
-            "standard_price": 50.0,
-            "purchase_ok": True,
-            "seller_ids": [(0, 0, {
-                "partner_id": vendor.id,
-                "price": 99.0,
-                "min_qty": 100,
-            })],
-        })
+        product = self.env["product.product"].create(
+            {
+                "name": "Cable roll 100m",
+                "standard_price": 50.0,
+                "purchase_ok": True,
+                "seller_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "partner_id": vendor.id,
+                            "price": 99.0,
+                            "min_qty": 100,
+                        },
+                    )
+                ],
+            }
+        )
         order = self.env["purchase.order"].create({"partner_id": vendor.id})
         catalog_product = product.with_context(
             product_catalog_order_model="purchase.order",
@@ -33,13 +41,55 @@ class TestProductCatalogTree(TransactionCase):
         # the vendor minimum quantity is exposed on the catalog row
         self.assertEqual(catalog_product.product_catalog_min_qty, 100)
 
-        # the new button adds the product with the vendor min_qty (mirrors the
-        # kanban catalog) instead of a hardcoded 1 like the ``+`` button
-        catalog_product.add_catalog_min_qty()
+        # the button sets the product to the vendor min_qty instead of a
+        # hardcoded 1 like the ``+`` button
+        catalog_product.set_catalog_min_qty()
         line = order.order_line.filtered(lambda line: line.product_id == product)
         self.assertEqual(line.product_qty, 100)
 
         # therefore the vendor price applies, not the product cost (50)
+        self.assertEqual(line.price_unit, 99.0)
+
+    def test_set_catalog_min_qty_replaces_existing_qty(self):
+        """When the product is already on the order the button replaces the
+        quantity with the vendor min_qty (it does not add one)."""
+        if "purchase.order" not in self.env:
+            self.skipTest("purchase is not installed")
+
+        vendor = self.env["res.partner"].create({"name": "Vendor Replace"})
+        product = self.env["product.product"].create(
+            {
+                "name": "Cable roll replace",
+                "standard_price": 50.0,
+                "purchase_ok": True,
+                "seller_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "partner_id": vendor.id,
+                            "price": 99.0,
+                            "min_qty": 100,
+                        },
+                    )
+                ],
+            }
+        )
+        order = self.env["purchase.order"].create({"partner_id": vendor.id})
+        catalog_product = product.with_context(
+            product_catalog_order_model="purchase.order",
+            order_id=order.id,
+        )
+
+        # the product already has a quantity below the vendor minimum
+        catalog_product.increase_quantity()
+        line = order.order_line.filtered(lambda line: line.product_id == product)
+        self.assertEqual(line.product_qty, 1)
+
+        # clicking the truck replaces the quantity with the vendor min_qty
+        # (instead of adding one, which was the bug), so the vendor price applies
+        catalog_product.set_catalog_min_qty()
+        self.assertEqual(line.product_qty, 100)
         self.assertEqual(line.price_unit, 99.0)
 
     def test_increase_quantity_keeps_adding_one(self):
@@ -48,16 +98,24 @@ class TestProductCatalogTree(TransactionCase):
             self.skipTest("purchase is not installed")
 
         vendor = self.env["res.partner"].create({"name": "Vendor Plus"})
-        product = self.env["product.product"].create({
-            "name": "Cable roll plus",
-            "standard_price": 50.0,
-            "purchase_ok": True,
-            "seller_ids": [(0, 0, {
-                "partner_id": vendor.id,
-                "price": 99.0,
-                "min_qty": 100,
-            })],
-        })
+        product = self.env["product.product"].create(
+            {
+                "name": "Cable roll plus",
+                "standard_price": 50.0,
+                "purchase_ok": True,
+                "seller_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "partner_id": vendor.id,
+                            "price": 99.0,
+                            "min_qty": 100,
+                        },
+                    )
+                ],
+            }
+        )
         order = self.env["purchase.order"].create({"partner_id": vendor.id})
         catalog_product = product.with_context(
             product_catalog_order_model="purchase.order",

--- a/product_catalog_tree/views/product_product_views.xml
+++ b/product_catalog_tree/views/product_product_views.xml
@@ -18,8 +18,8 @@
                 <field name="product_catalog_qty"/>
                 <field name="product_catalog_min_qty" column_invisible="1"/>
                 <button name="increase_quantity" type="object" icon="fa-plus" title="Add one"/>
-                <button name="add_catalog_min_qty" type="object" icon="fa-truck"
-                        title="Add supplier minimum quantity"
+                <button name="set_catalog_min_qty" type="object" icon="fa-truck"
+                        title="Set supplier minimum quantity"
                         invisible="not product_catalog_min_qty or product_catalog_min_qty &lt;= 1"/>
             </field>
             <field name="standard_price" position="after">

--- a/product_catalog_tree/views/product_product_views.xml
+++ b/product_catalog_tree/views/product_product_views.xml
@@ -16,7 +16,11 @@
                 </list>
             <field name="is_favorite" position="after">
                 <field name="product_catalog_qty"/>
-                <button name="increase_quantity" type='object' icon='fa-plus' title='Add one'></button>
+                <field name="product_catalog_min_qty" column_invisible="1"/>
+                <button name="increase_quantity" type="object" icon="fa-plus" title="Add one"/>
+                <button name="add_catalog_min_qty" type="object" icon="fa-truck"
+                        title="Add supplier minimum quantity"
+                        invisible="not product_catalog_min_qty or product_catalog_min_qty &lt;= 1"/>
             </field>
             <field name="standard_price" position="after">
                 <field name="product_catalog_price"/>


### PR DESCRIPTION
### Problem

In the **list-view** catalog the `+` button (`increase_quantity`) always adds 1
unit. The **kanban** catalog instead suggests the vendor's `min_qty` on the
first add (see `purchase` `product_catalog/kanban_record.js` → `addProduct`).

As a consequence, adding a product whose vendor `min_qty` is greater than the
added quantity from the list catalog selects no seller, and the price falls
back to the product cost — while doing the same from the kanban catalog applies
the vendor price. Same product, different price depending on the view used.

### Change

- Expose `product_catalog_min_qty` on the catalog row (taken from the catalog
  payload `min_qty`).
- Add a dedicated button `add_catalog_min_qty` that mirrors the kanban
  behaviour: on the first add it uses the vendor `min_qty` (so the vendor price
  applies instead of the cost); once the line already exists it adds one, like
  the `+` button. The button is only shown when the vendor `min_qty` is greater
  than 1.
- Add tests (skipped when `purchase` is not installed).

The existing `+` button keeps its behaviour unchanged.
