### PR TITLE
[FIX] product_planned_price: compute planned price with operating com…

### DIFF
--- a/product_planned_price/models/product_template.py
+++ b/product_planned_price/models/product_template.py
@@ -70,12 +70,13 @@ class ProductTemplate(models.Model):
     warnings_price = fields.Json(compute="_compute_warnings_price")
 
     @api.depends("company_id")
+    @api.depends_context("company")
     def _compute_main_company(self):
-        main_company = self.env["res.company"]._get_main_company()
         for rec in self:
-            rec.main_company_id = rec.company_id or main_company
+            rec.main_company_id = rec.company_id or self.env.company
 
     @api.depends("replenishment_cost", "company_id")
+    @api.depends_context("company")
     def _compute_replenishment_cost_main_company(self):
         for rec in self:
             rec.replenishment_cost_main_company = rec.sudo().with_company(rec.main_company_id.id).replenishment_cost
@@ -157,6 +158,7 @@ class ProductTemplate(models.Model):
         "other_currency_list_price",
         "other_currency_id",
     )
+    @api.depends_context("company")
     def _compute_computed_list_price(self):
         recs = self.filtered(lambda x: x.list_price_type in ["manual", "by_margin", "other_currency"])
         _logger.info('Get computed_list_price for %s "manual", "by_margin" and "other_currency" products' % (len(recs)))

--- a/product_planned_price/tests/__init__.py
+++ b/product_planned_price/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_planned_price_company

--- a/product_planned_price/tests/test_planned_price_company.py
+++ b/product_planned_price/tests/test_planned_price_company.py
@@ -1,0 +1,53 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestPlannedPriceCompany(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.main_company = self.env.ref("base.main_company")
+        self.currency = self.main_company.currency_id
+        self.aux_company = self.env["res.company"].create(
+            {
+                "name": "Aux Co (121458)",
+                "currency_id": self.currency.id,
+            }
+        )
+        self.supplier = self.env["res.partner"].create({"name": "Proveedor 121458"})
+        self.product = self.env["product.template"].create(
+            {
+                "name": "Producto 121458",
+                "type": "consu",
+                "list_price_type": "by_margin",
+                "sale_margin": 50.0,
+                "sale_surcharge": 0.0,
+                "replenishment_cost_type": "supplier_price",
+            }
+        )
+        self.env["product.supplierinfo"].create(
+            {
+                "product_tmpl_id": self.product.id,
+                "partner_id": self.supplier.id,
+                "company_id": self.aux_company.id,
+                "currency_id": self.currency.id,
+                "price": 100.0,
+            }
+        )
+
+    def test_planned_price_uses_operating_company_cost(self):
+        product_aux = self.product.with_company(self.aux_company)
+
+        self.assertEqual(
+            product_aux.replenishment_cost,
+            100.0,
+            "Replenishment cost should resolve to 100 in the auxiliary company",
+        )
+
+        self.assertEqual(
+            product_aux.computed_list_price,
+            150.0,
+            "Planned price should be computed with the operating company cost " "(150), not the main company one (0)",
+        )


### PR DESCRIPTION
…pany cost

El precio planificado por margen leia el costo de reposicion forzando la compania principal (_get_main_company()). Como el costo de reposicion es company_dependent, cuando el cliente mantiene el costo en una compania auxiliar el calculo daba 0 y el precio de venta quedaba fijo.

Ahora el precio planificado usa el costo de la compania operativa (company_id del producto o la activa) y recalcula por compania (depends_context company).