### PR TITLE
[FIX] price_security: use product_uom_id key in check_discount tmp vals

### DIFF
--- a/price_security/models/res_users.py
+++ b/price_security/models/res_users.py
@@ -27,7 +27,7 @@ class Users(models.Model):
             tmp_line_vals = {
                 "product_id": so_line.product_id.id,
                 "order_id": so_line.order_id.id,
-                "product_uom": so_line.product_uom_id.id,
+                "product_uom_id": so_line.product_uom_id.id,
                 "product_uom_qty": so_line.product_uom_qty,
             }
             # for compatibility with product_pack


### PR DESCRIPTION
## Summary

In Odoo 19, `sale.order.line`'s UoM field was renamed to `product_uom_id`. The temp vals dict built in `res_users.check_discount()` (used to preview a line's discount against the pricelist) still used the old `product_uom` key. `so_line.new()` validates dict keys against the model's actual fields, so this raised:

```
ValueError: Invalid field 'product_uom' on model 'sale.order.line'
```

This broke both order confirmation and the sales Catalog for any user in the `price_security.group_only_view` group (Salesperson with "Only see sale price") whenever `sale_order_line.check_discount` triggered a discount check.

## Change

One-line fix in `price_security/models/res_users.py`: rename the dict key from `product_uom` to `product_uom_id` (the value being assigned, `so_line.product_uom_id.id`, was already correct).

## Test plan

- As a user in `group_only_view`, add a product line to a quotation and confirm the sale order — should no longer raise a server error.
- As the same user, open the sales Catalog from a quotation and add products — should no longer raise a server error.
- Ref: Adhoc ticket #121798.