### PR TITLE
[MIG] product_replenishment_cost_sale_margin: Migration to 19.0

### DIFF
--- a/product_replenishment_cost_sale_margin/__manifest__.py
+++ b/product_replenishment_cost_sale_margin/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Use Replenishment Cost on Sale Margin",
-    "version": "18.0.1.0.0",
+    "version": "19.0.1.0.0",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Products",
@@ -9,5 +9,5 @@
         "sale_margin",
     ],
     "data": [],
-    "installable": False,
+    "installable": True,
 }

--- a/product_replenishment_cost_sale_margin/models/sale_order_line.py
+++ b/product_replenishment_cost_sale_margin/models/sale_order_line.py
@@ -9,7 +9,7 @@ class SaleOrderLine(models.Model):
         for line in self.filtered("product_id"):
             order_id = line.order_id
             product_id = line.product_id
-            product_uom_id = line.product_uom
+            product_uom_id = line.product_uom_id
             if product_id.replenishment_cost:
                 frm_cur = product_id.currency_id
                 to_cur = order_id.currency_id
@@ -32,8 +32,8 @@ class SaleOrderLine(models.Model):
             frm_cur = self.product_id.currency_id
             to_cur = self.currency_id or self.order_id.currency_id
             purchase_price = self.product_id.replenishment_cost
-            if self.product_uom != from_uom:
-                purchase_price = from_uom._compute_price(purchase_price, self.product_uom)
+            if self.product_uom_id != from_uom:
+                purchase_price = from_uom._compute_price(purchase_price, self.product_uom_id)
             return frm_cur._convert(
                 purchase_price,
                 to_cur,


### PR DESCRIPTION
## Migration to 19.0

Migrates `product_replenishment_cost_sale_margin` to 19.0.

### Changes
- `__manifest__.py`: bump version to `19.0.1.0.0`, set `installable: True`.
- `models/sale_order_line.py`: adapt to the `sale.order.line` field rename `product_uom` → `product_uom_id` (the only breaking change on 19.0). All existing logic is preserved — no behavior change.

### Test plan
- Module installs on 19.0 (deps `product_replenishment_cost` + `sale_margin` already available).
- On a sale order line whose product has a `replenishment_cost`, `purchase_price` (the margin base) is computed from the replenishment cost, converted to the order currency/date and to the line UoM.
- Products without `replenishment_cost` keep Odoo's standard margin behavior.

Task: https://www.adhoc.inc/odoo/all-tasks/70102
