### PR TITLE
[I18N] stock_account_cost_revaluation: add Spanish translation

### DIFF
--- a/stock_account_cost_revaluation/i18n/es.po
+++ b/stock_account_cost_revaluation/i18n/es.po
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_account_cost_revaluation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-29 20:03+0000\n"
+"PO-Revision-Date: 2026-06-29 20:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model.fields,field_description:stock_account_cost_revaluation.field_product_category__property_cost_revaluation_account_id
+msgid "Cost Revaluation Account"
+msgstr "Cuenta de revaluación de costo"
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model.fields,help:stock_account_cost_revaluation.field_product_category__property_cost_revaluation_account_id
+msgid ""
+"Cuenta de resultado (contrapartida) del asiento de revaluación de inventario"
+" que se genera al cambiar el costo contable (standard_price) de productos "
+"con valoración perpetua. Si no se define, no se genera el asiento."
+msgstr ""
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model.fields,field_description:stock_account_cost_revaluation.field_product_category__display_name
+#: model:ir.model.fields,field_description:stock_account_cost_revaluation.field_product_product__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model.fields,field_description:stock_account_cost_revaluation.field_product_category__id
+#: model:ir.model.fields,field_description:stock_account_cost_revaluation.field_product_product__id
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model,name:stock_account_cost_revaluation.model_product_category
+msgid "Product Category"
+msgstr "Categoría de producto"
+
+#. module: stock_account_cost_revaluation
+#: model:ir.model,name:stock_account_cost_revaluation.model_product_product
+msgid "Product Variant"
+msgstr "Variante de producto"
+
+#. module: stock_account_cost_revaluation
+#. odoo-python
+#: code:addons/stock_account_cost_revaluation/models/product_product.py:0
+msgid "Revaluación de costo: %s"
+msgstr ""


### PR DESCRIPTION
Adds the Spanish (`es`) translation for the `stock_account_cost_revaluation` module.

Translated: field label "Cost Revaluation Account", "Display Name", "Product Category", "Product Variant".

Note: two source terms are already written in Spanish in the code (the field help and the `Revaluación de costo: %s` message), so their `msgstr` is left empty — they should be rewritten in English in the source to be properly translatable.