### PR TITLE
[IMP] product_stock_by_location: show location stock by default

### DIFF
--- a/product_stock_by_location/__manifest__.py
+++ b/product_stock_by_location/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     "name": "Product Stock By Location",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "Tools",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/product_stock_by_location/models/product_template.py
+++ b/product_stock_by_location/models/product_template.py
@@ -18,7 +18,9 @@ class ProductTemplate(models.Model):
     @api.depends("name")
     def _compute_location_ids(self):
         for rec in self:
-            rec.location_ids = rec.location_ids.search([("show_stock_on_products", "=", True)])
+            rec.location_ids = rec.location_ids.search(
+                [("show_stock_on_products", "=", True), ("usage", "=", "internal")]
+            )
 
     def view_stock_detail(self):
         self.ensure_one()

--- a/product_stock_by_location/models/stock_location.py
+++ b/product_stock_by_location/models/stock_location.py
@@ -9,7 +9,11 @@ class StockLocation(models.Model):
     _inherit = "stock.location"
 
     show_stock_on_products = fields.Boolean(
-        help="If true, this location will be shown on the pop up window opened" "from products kanban and list view"
+        default=True,
+        help="If set, this location's stock is shown on products: the stock detail on"
+        " sale order lines and the pop up window opened from the products kanban and"
+        " list view. Enabled by default; uncheck it on locations you do not want to"
+        " expose (e.g. scrap/discard locations modelled as internal).",
     )
     qty_available = fields.Float(
         compute="_compute_product_available",


### PR DESCRIPTION
## Qué

Invierte el default de `stock.location.show_stock_on_products` a `True`: el detalle de stock por ubicación pasa a mostrarse por defecto (opt-out) en vez de estar oculto hasta prenderlo ubicación por ubicación (opt-in).

Afecta a los dos consumidores del flag:
- El widget de stock por ubicación en las líneas del pedido de venta (`sale_stock_ux`).
- El pop up de stock por ubicación del producto (`product_stock_by_location`).

## Por qué

Al migrar de 17/18 a 19, los usuarios dejaban de ver la disponibilidad por ubicación que veían antes, porque en 19 el detalle pasó a ser configurable por ubicación y arrancaba apagado. Con el default en `True`, "verlo" vuelve a ser lo normal y "esconderlo" (típicamente ubicaciones de descarte modeladas como internas) la excepción.

## Cambios

- `models/stock_location.py`: `show_stock_on_products` con `default=True` + help actualizado.
- `models/product_template.py`: el pop up ahora filtra las ubicaciones por `usage='internal'`, para que el nuevo default no exponga ubicaciones no internas (cliente/proveedor) en ese listado.
- Bump de versión `19.0.1.0.0` → `19.0.2.0.0`.

## Nota de migración

El `default` solo aplica a ubicaciones nuevas. El backfill de las ubicaciones internas existentes, para las bases que migran de 17/18, va en un PR aparte en `odoo-upgrade` — corre solo en el pase de versión, así que no pisa las bases ya en 19 donde un `False` puede ser una decisión deliberada.

## Test plan

- Crear una ubicación interna nueva → `show_stock_on_products` viene en `True`.
- Producto con stock en esa ubicación → aparece en el detalle de la línea de venta y en el pop up del producto.
- Apagar el flag en una ubicación → deja de mostrarse en ambos lugares.
- El pop up del producto no lista ubicaciones no internas.

Task: https://www.adhoc.inc/odoo/knowledge/180/project.task/70789
