### PR TITLE
[FIX] product_replenishment_cost: correct misleading update wizard message

### DIFF
--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Replenishment Cost",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Products",

--- a/product_replenishment_cost/i18n/product_replenishment_cost.pot
+++ b/product_replenishment_cost/i18n/product_replenishment_cost.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 15:00+0000\n"
-"PO-Revision-Date: 2026-04-27 15:00+0000\n"
+"POT-Creation-Date: 2026-07-22 14:00+0000\n"
+"PO-Revision-Date: 2026-07-22 14:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -427,8 +427,8 @@ msgstr ""
 #. module: product_replenishment_cost
 #: model_terms:ir.ui.view,arch_db:product_replenishment_cost.view_update_from_replenishment_cost_wizard_form
 msgid ""
-"This will apply to all the selected products across company with costing "
-"method \"Standard Price\" and with Replenishment Cost different from 0."
+"This will apply to all the selected products across company with a "
+"Replenishment Cost different from 0."
 msgstr ""
 
 #. module: product_replenishment_cost

--- a/product_replenishment_cost/wizards/product_update_from_replenishment_cost_wizard_views.xml
+++ b/product_replenishment_cost/wizards/product_update_from_replenishment_cost_wizard_views.xml
@@ -6,7 +6,7 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Product Catalog Report">
-                This will apply to all the selected products across company with costing method "Standard Price" and with Replenishment Cost different from 0.
+                This will apply to all the selected products across company with a Replenishment Cost different from 0.
                 <footer>
                     <button name="confirm" string="Confirm" type="object" class="oe_highlight"/>
                     or


### PR DESCRIPTION
The "Update Accounting Cost from Replenishment Cost" wizard message stated the action only applied to products with the **"Standard Price"** costing method:

> This will apply to all the selected products across company with costing method "Standard Price" and with Replenishment Cost different from 0.

However, `_update_cost_from_replenishment_cost()` in `product_template.py` overwrites `standard_price` for products of **any** costing method — it only filters `replenishment_cost != 0` and never checks the category costing method. This was reproduced on an **AVCO** category, where the cost went from `0` to a non-zero value on confirm.

## Change

The action itself is intentional (useful e.g. for currency-based valuation), so the behavior is **not** blocked. Only the wizard message is corrected so it no longer restricts the scope to the `"Standard Price"` costing method:

> This will apply to all the selected products across company with a Replenishment Cost different from 0.

Source terms re-exported (`.pot`). Translations are handled by the usual Transifex sync.

## Test plan

- Open a product list, select products in a category using AVCO (or FIFO) with a Replenishment Cost != 0.
- Run **Update Accounting Cost from Replenishment Cost**.
- The wizard message no longer claims it only applies to "Standard Price"; confirming still updates the accounting cost as before.

Ref: https://www.adhoc.inc/odoo/action-helpdesk.helpdesk_ticket_action_main/123474