### PR TITLE
[FIX] price_security: discount restriction on lines added from the ca…

### DIFF
--- a/price_security/models/res_users.py
+++ b/price_security/models/res_users.py
@@ -4,6 +4,7 @@
 ##############################################################################
 from odoo import _, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_compare, float_is_zero
 
 
 class Users(models.Model):
@@ -39,7 +40,7 @@ class Users(models.Model):
         discount_precision_digits = self.env["decimal.precision"].precision_get("Discount")
         net_discount = discount - round(pricelist_disc, discount_precision_digits)
 
-        if net_discount and net_discount != 0.0:
+        if not float_is_zero(net_discount, precision_digits=discount_precision_digits):
             disc_restriction_env = self.env["res.users.discount_restriction"]
             domain = [("pricelist_id", "=", pricelist_id), ("user_id", "=", self.id)]
             disc_restriction = disc_restriction_env.search(domain, limit=1)
@@ -53,7 +54,16 @@ class Users(models.Model):
                 if pricelist_disc:
                     error += ' (%s%% for product "%s")' % (pricelist_disc, so_line.product_id.name)
             else:
-                if net_discount < disc_restriction.min_discount or net_discount > disc_restriction.max_discount:
+                if (
+                    float_compare(
+                        net_discount, disc_restriction.min_discount, precision_digits=discount_precision_digits
+                    )
+                    < 0
+                    or float_compare(
+                        net_discount, disc_restriction.max_discount, precision_digits=discount_precision_digits
+                    )
+                    > 0
+                ):
                     error = _(
                         'The applied discount is not allowed. Discount must bebetween %s and %s for pricelist "%s"'
                     ) % (

--- a/price_security/models/sale_order_line.py
+++ b/price_security/models/sale_order_line.py
@@ -12,13 +12,27 @@ class SaleOrderLine(models.Model):
         related="product_id.can_modify_prices",
     )
 
-    @api.constrains(
-        "discount",
-        "product_id",
-        # this is a related none stored field
-        # 'product_can_modify_prices'
-    )
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        lines._price_security_settle_discount(vals_list)
+        lines.check_discount()
+        return lines
+
+    def write(self, vals):
+        res = super().write(vals)
+        if {"discount", "discount1", "discount2", "discount3", "product_id"} & vals.keys():
+            self.check_discount()
+        return res
+
+    def _price_security_settle_discount(self, vals_list):
+        """Hook for modules that rewire the discount computation (e.g.
+        sale_triple_discount) and need to settle it before validation. `self` are the
+        lines just created, aligned with `vals_list`."""
+
     def check_discount(self):
+        # Validated after create/write instead of api.constrains, which ran during the
+        # create flush and could compare transient not-yet-computed discount values.
         if not self.env.user.has_group("price_security.group_only_view"):
             return True
         for rec in self.filtered(lambda x: not x.product_can_modify_prices):

--- a/price_security/tests/__init__.py
+++ b/price_security/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_discount_restriction

--- a/price_security/tests/test_discount_restriction.py
+++ b/price_security/tests/test_discount_restriction.py
@@ -1,0 +1,114 @@
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, new_test_user, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDiscountRestriction(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref("base.user_root").group_ids += cls.env.ref("sale.group_discount_per_so_line")
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "Discount Restriction Pricelist",
+                "item_ids": [
+                    Command.create(
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "percentage",
+                            "percent_price": 30.0,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Discount Restriction Customer",
+                "property_product_pricelist": cls.pricelist.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Discount Restriction Product",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+        cls.seller = new_test_user(
+            cls.env,
+            login="price_security_seller",
+            groups="sales_team.group_sale_salesman,price_security.group_only_view",
+        )
+        cls.env["res.users.discount_restriction"].create(
+            {
+                "user_id": cls.seller.id,
+                "pricelist_id": cls.pricelist.id,
+                "min_discount": 0.0,
+                "max_discount": 10.0,
+            }
+        )
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "pricelist_id": cls.pricelist.id,
+                "user_id": cls.seller.id,
+            }
+        )
+        # sale_exception_price_security (auto-installed with sale_exception) disables
+        # the immediate UserError and defers enforcement to a blocking sale exception
+        # on order confirmation.
+        cls.deferred_check = (
+            cls.env["ir.module.module"].search([("name", "=", "sale_exception_price_security")]).state == "installed"
+        )
+
+    def _assert_restriction_blocks(self, apply_discount):
+        if self.deferred_check:
+            apply_discount()
+            self.order.with_user(self.seller).action_confirm()
+            self.assertEqual(self.order.state, "draft")
+            self.assertIn(
+                self.env.ref("sale_exception_price_security.discount_restriction"),
+                self.order.exception_ids,
+            )
+        else:
+            with self.assertRaises(UserError):
+                apply_discount()
+
+    def _create_line(self, **extra_vals):
+        vals = {
+            "order_id": self.order.id,
+            "product_id": self.product.id,
+            "product_uom_qty": 1,
+            **extra_vals,
+        }
+        return self.env["sale.order.line"].with_user(self.seller).create(vals)
+
+    def _apply_extra_discount(self, line, extra):
+        """Apply a manual discount on top of the 30% pricelist discount, through the
+        channel available in the installed discount stack: with sale_triple_discount
+        `discount` becomes readonly (and sale_triple_discount_lock forces discount1 to
+        the pricelist discount), so discount3 is the manual channel there."""
+        if "discount3" in line._fields:
+            line.with_user(self.seller).write({"discount3": extra})
+            # combined discount: 100 * (1 - 0.7 * (1 - extra / 100))
+            return 100 - 70.0 * (1 - extra / 100.0)
+        line.with_user(self.seller).write({"discount": 30.0 + extra})
+        return 30.0 + extra
+
+    def test_create_without_discount_keeps_pricelist_discount(self):
+        # Lines created without explicit discount (e.g. from the product catalog)
+        # must end up with the pricelist discount and pass the restriction check.
+        line = self._create_line()
+        self.assertAlmostEqual(line.discount, 30.0, places=2)
+
+    def test_discount_above_restriction_is_blocked(self):
+        line = self._create_line()
+        # extra 25% -> net discount over the 10% allowed
+        self._assert_restriction_blocks(lambda: self._apply_extra_discount(line, 25.0))
+
+    def test_discount_within_restriction_is_allowed(self):
+        line = self._create_line()
+        expected = self._apply_extra_discount(line, 10.0)
+        self.assertAlmostEqual(line.discount, expected, places=2)

--- a/price_security_sale_triple_discount/__init__.py
+++ b/price_security_sale_triple_discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/price_security_sale_triple_discount/__manifest__.py
+++ b/price_security_sale_triple_discount/__manifest__.py
@@ -1,0 +1,33 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Price Security with Sale Triple Discount",
+    "version": "19.0.1.0.0",
+    "category": "Sales Management",
+    "author": "ADHOC SA",
+    "website": "http://www.adhoc.com.ar/",
+    "license": "AGPL-3",
+    "depends": [
+        "price_security",
+        "sale_triple_discount",
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/price_security_sale_triple_discount/models/__init__.py
+++ b/price_security_sale_triple_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/price_security_sale_triple_discount/models/sale_order_line.py
+++ b/price_security_sale_triple_discount/models/sale_order_line.py
@@ -1,0 +1,22 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _price_security_settle_discount(self, vals_list):
+        # sale_triple_discount rewires discount as a compute over discount1/2/3, whose
+        # circular compute/inverse chain leaves the pricelist discount unsettled during
+        # the create flush: lines created without an explicit discount (e.g. adding
+        # products from the catalog view) transiently read 0.0 and were wrongly
+        # rejected by the discount restriction check. Re-marking the fields to compute
+        # makes the next read (the restriction check) resolve the settled values.
+        super()._price_security_settle_discount(vals_list)
+        discount_fields = {"discount", "discount1", "discount2", "discount3"}
+        to_settle = self.browse(line.id for line, vals in zip(self, vals_list) if not discount_fields & vals.keys())
+        for fname in to_settle and ("discount1", "discount2", "discount3", "discount") or ():
+            self.env.add_to_compute(self._fields[fname], to_settle)

--- a/price_security_sale_triple_discount/tests/__init__.py
+++ b/price_security_sale_triple_discount/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_triple_discount_restriction

--- a/price_security_sale_triple_discount/tests/test_triple_discount_restriction.py
+++ b/price_security_sale_triple_discount/tests/test_triple_discount_restriction.py
@@ -1,0 +1,107 @@
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, new_test_user, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTripleDiscountRestriction(TransactionCase):
+    """Reproduces adding products from the catalog view as a user with discount
+    restrictions: the line is created without explicit discount values and the
+    pricelist discount must settle before the restriction check runs.
+
+    Manual discounts are applied through discount3: discount is readonly with
+    sale_triple_discount, and sale_triple_discount_lock (if installed) forces
+    discount1 back to the pricelist discount."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref("base.user_root").group_ids += cls.env.ref("sale.group_discount_per_so_line")
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "Triple Discount Restriction Pricelist",
+                "item_ids": [
+                    Command.create(
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "percentage",
+                            "percent_price": 30.0,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Triple Discount Restriction Customer",
+                "property_product_pricelist": cls.pricelist.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Triple Discount Restriction Product",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+        cls.seller = new_test_user(
+            cls.env,
+            login="triple_discount_seller",
+            groups="sales_team.group_sale_salesman,price_security.group_only_view",
+        )
+        cls.env["res.users.discount_restriction"].create(
+            {
+                "user_id": cls.seller.id,
+                "pricelist_id": cls.pricelist.id,
+                "min_discount": 0.0,
+                "max_discount": 10.0,
+            }
+        )
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "pricelist_id": cls.pricelist.id,
+                "user_id": cls.seller.id,
+            }
+        )
+        # sale_exception_price_security (auto-installed with sale_exception) disables
+        # the immediate UserError and defers enforcement to a blocking sale exception
+        # on order confirmation.
+        cls.deferred_check = (
+            cls.env["ir.module.module"].search([("name", "=", "sale_exception_price_security")]).state == "installed"
+        )
+
+    def _create_line(self, **extra_vals):
+        vals = {
+            "order_id": self.order.id,
+            "product_id": self.product.id,
+            "product_uom_qty": 1,
+            **extra_vals,
+        }
+        return self.env["sale.order.line"].with_user(self.seller).create(vals)
+
+    def test_catalog_style_create_keeps_pricelist_discount(self):
+        line = self._create_line()
+        self.assertAlmostEqual(line.discount, 30.0, places=2)
+        self.assertAlmostEqual(line.discount1, 30.0, places=2)
+
+    def test_extra_discount_within_restriction_is_allowed(self):
+        line = self._create_line()
+        # extra 10% on discount3 -> combined 37%, net 7% within the allowed 10%
+        line.with_user(self.seller).write({"discount3": 10.0})
+        self.assertAlmostEqual(line.discount, 37.0, places=2)
+
+    def test_extra_discount_above_restriction_is_blocked(self):
+        line = self._create_line()
+        # extra 25% on discount3 -> combined 47.5%, net 17.5% over the allowed 10%
+        if self.deferred_check:
+            line.with_user(self.seller).write({"discount3": 25.0})
+            self.order.with_user(self.seller).action_confirm()
+            self.assertEqual(self.order.state, "draft")
+            self.assertIn(
+                self.env.ref("sale_exception_price_security.discount_restriction"),
+                self.order.exception_ids,
+            )
+        else:
+            with self.assertRaises(UserError):
+                line.with_user(self.seller).write({"discount3": 25.0})


### PR DESCRIPTION
…talog

The api.constrains on discount ran during the create flush, comparing discount values that may not be settled yet. With sale_triple_discount installed, its circular compute/inverse chain over discount1/2/3 leaves the pricelist discount unsettled at that point, so lines created without an explicit discount (e.g. adding products from the catalog view) transiently read 0.0 and were wrongly rejected for users with discount restrictions, while the same product added from the order form (which sends discount1 explicitly) passed.

- price_security: validate at the end of create/write instead of the constraint, expose the _price_security_settle_discount hook, and compare net discounts using float precision (discount arithmetic can produce values like 32.99999999999999 that failed strict comparison).
- price_security_sale_triple_discount: new auto-installable bridge module that settles the triple discount compute chain for lines created without explicit discount before the restriction validation.