### PR TITLE
[FIX] product_replenishment_cost: retry cron on PG concurrency errors

### DIFF
--- a/product_replenishment_cost/__manifest__.py
+++ b/product_replenishment_cost/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Replenishment Cost",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.3.1",
     "author": "ADHOC SA, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Products",

--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -3,8 +3,11 @@
 # directory
 ##############################################################################
 import logging
+import random
+import time
 
 from odoo import _, api, fields, models
+from odoo.service.model import MAX_TRIES_ON_CONCURRENCY_FAILURE, PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
@@ -103,6 +106,51 @@ class ProductTemplate(models.Model):
 
     @api.model
     def cron_update_cost_from_replenishment_cost(self, limit=None, company_ids=None, batch_size=1000):
+        """Reintenta el batch ante errores de concurrencia de PostgreSQL.
+
+        A diferencia de las peticiones HTTP, que Odoo reintenta automáticamente ante un
+        error de serialización/deadlock (ver ``odoo.service.model.retrying``), los crons
+        propagan la excepción y el job queda marcado como fallido. Como el UPDATE masivo
+        sobre ``product_product.standard_price`` puede chocar con otro proceso que escriba
+        las mismas filas, envolvemos el batch en un loop de reintentos con backoff
+        exponencial, replicando el mismo conjunto de errores y la misma cantidad de
+        intentos que usa el core. Si se agotan los intentos, se relanza la excepción para
+        que el cron quede en estado fallido en lugar de silenciarla.
+
+        NOTA: esto mitiga locks transitorios; una colisión sostenida contra el mismo
+        proceso escritor necesita resolverse en el origen del lock, no acá.
+        """
+        for attempt in range(1, MAX_TRIES_ON_CONCURRENCY_FAILURE + 1):
+            try:
+                return self._cron_update_cost_from_replenishment_cost(
+                    limit=limit, company_ids=company_ids, batch_size=batch_size
+                )
+            except PG_CONCURRENCY_EXCEPTIONS_TO_RETRY as exc:
+                # la transacción quedó abortada: rollback y reset de caché del ORM antes
+                # de reintentar, para releer estado limpio (igual que el core).
+                self.env.cr.rollback()
+                self.env.transaction.reset()
+                if attempt == MAX_TRIES_ON_CONCURRENCY_FAILURE:
+                    _logger.error(
+                        "cron_update_cost_from_replenishment_cost: error de concurrencia (%s) "
+                        "tras %s intentos, se aborta y el job queda fallido.",
+                        exc.__class__.__name__,
+                        MAX_TRIES_ON_CONCURRENCY_FAILURE,
+                    )
+                    raise
+                wait_time = random.uniform(0.0, 2**attempt)
+                _logger.warning(
+                    "cron_update_cost_from_replenishment_cost: error de concurrencia (%s), "
+                    "intento %s/%s, reintentando en %.2fs",
+                    exc.__class__.__name__,
+                    attempt,
+                    MAX_TRIES_ON_CONCURRENCY_FAILURE,
+                    wait_time,
+                )
+                time.sleep(wait_time)
+
+    @api.model
+    def _cron_update_cost_from_replenishment_cost(self, limit=None, company_ids=None, batch_size=1000):
         """vamos a actualizar de a batches y guardar en un parametro cual es el ultimo que se actualizó.
         si hay mas por actualizar llamamos con trigger al mismo cron para que siga con el prox batch
         si terminamos, resetamos el parametro a 0 para que en proxima corrida arranque desde abajo

--- a/product_replenishment_cost/tests/test_product_template.py
+++ b/product_replenishment_cost/tests/test_product_template.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+
+import psycopg2
+from odoo.service.model import MAX_TRIES_ON_CONCURRENCY_FAILURE
 from odoo.tests.common import TransactionCase
 
 
@@ -104,3 +108,55 @@ class TestUpdateCostFromReplenishmentCost(TransactionCase):
         self.product_template._update_cost_from_replenishment_cost()
 
         self.assertEqual(product.standard_price, 80.0)
+
+
+class TestCronUpdateCostRetry(TransactionCase):
+    """Reintento del cron ante errores de concurrencia de PostgreSQL.
+
+    No se puede provocar un SerializationFailure real de forma determinística, así que
+    inyectamos la falla parcheando el helper propio ``_cron_update_cost_from_replenishment_cost``
+    (no primitivas del ORM). La escritura real del batch ya está cubierta por
+    ``TestUpdateCostFromReplenishmentCost``; acá validamos solo el control de reintentos.
+    Además parcheamos ``cr.rollback`` (el framework de tests lo prohíbe) y ``time.sleep``
+    para no penalizar la corrida.
+    """
+
+    def test_cron_retries_and_succeeds_on_serialization_failure(self):
+        ProductTemplate = self.env["product.template"]
+        calls = {"n": 0}
+
+        def _flaky(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise psycopg2.errors.SerializationFailure()
+            return True
+
+        with patch.object(
+            type(ProductTemplate),
+            "_cron_update_cost_from_replenishment_cost",
+            side_effect=_flaky,
+        ), patch.object(self.env.cr, "rollback", lambda: None), patch("time.sleep", lambda *args: None):
+            result = ProductTemplate.cron_update_cost_from_replenishment_cost(company_ids=[self.env.company.id])
+
+        # un fallo transitorio + un reintento exitoso
+        self.assertEqual(calls["n"], 2)
+        self.assertTrue(result)
+
+    def test_cron_reraises_after_max_retries(self):
+        ProductTemplate = self.env["product.template"]
+        calls = {"n": 0}
+
+        def _always_fail(*args, **kwargs):
+            calls["n"] += 1
+            raise psycopg2.errors.SerializationFailure()
+
+        with patch.object(
+            type(ProductTemplate),
+            "_cron_update_cost_from_replenishment_cost",
+            side_effect=_always_fail,
+        ), patch.object(self.env.cr, "rollback", lambda: None), patch("time.sleep", lambda *args: None):
+            with self.assertRaises(psycopg2.errors.SerializationFailure):
+                ProductTemplate.cron_update_cost_from_replenishment_cost(company_ids=[self.env.company.id])
+
+        # se agotan los MAX_TRIES intentos antes de relanzar
+        self.assertEqual(calls["n"], MAX_TRIES_ON_CONCURRENCY_FAILURE)


### PR DESCRIPTION
## Problema

El cron `cron_update_cost_from_replenishment_cost` hace un `UPDATE` masivo sobre `product_product.standard_price`. Si otro proceso tiene tomado un lock sobre las mismas filas, PostgreSQL aborta la transacción con un error de serialización (`could not serialize access due to concurrent update`) o deadlock.

A diferencia de las peticiones HTTP —que Odoo reintenta automáticamente ante estos errores (`odoo.service.model.retrying`)— los crons **no** tienen ese reintento: la excepción propaga al handler de `ir.cron` y el job queda marcado como *failed*, dejando el costo contable desactualizado hasta la próxima corrida.

Detectado en Boggio (tarea 70676): el cron fallaba consistentemente de madrugada por overlap con otro proceso que escribe `product_product`. Bajar el `batch_size` de 1000 a 200 mitigó parcialmente pero no resolvió.

## Solución

Se envuelve el batch en un loop de reintentos con backoff exponencial:

- Reusa el mismo set de excepciones del core (`PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`: `SerializationFailure` + `DeadlockDetected` + `LockNotAvailable`) en vez de capturar solo `SerializationFailure` — el mismo lock concurrente puede aflorar como deadlock.
- Reusa `MAX_TRIES_ON_CONCURRENCY_FAILURE` (5) y el backoff `random.uniform(0, 2**intento)`, igual que `retrying()`.
- Ante el error: `cr.rollback()` + `transaction.reset()` para releer estado limpio antes de reintentar.
- Agotados los intentos, **re-lanza** la excepción para que el job quede fallido en lugar de silenciarla.

El cuerpo original del método se movió a un helper privado `_cron_update_cost_from_replenishment_cost`; el método público (referenciado por el `ir.cron` y por `_trigger()`) mantiene su firma.

## Notas

- Es una mitigación de locks **transitorios**. Una colisión sostenida contra el mismo proceso escritor necesita resolverse en el origen del lock (queda como pendiente de la 70676).
- El default del cron es mensual, así que para el grueso de las bases la ventana de colisión es chica; esto es un seguro barato y genérico para todos los clientes.

## Tests

- `test_cron_retries_and_succeeds_on_serialization_failure`: falla transitoria + reintento exitoso.
- `test_cron_reraises_after_max_retries`: agota los 5 intentos y relanza.

Se inyecta la falla parcheando el helper propio (no primitivas del ORM); la escritura real del batch ya está cubierta por `TestUpdateCostFromReplenishmentCost`.

Origen: sugerencia de Dani Libonati a partir del PR de mitigación en `personalizations_boggio` (ingadhoc/personalizations#3618). Tareas 71404 / 70676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)