### PR TITLE
[FIX] product_replenishment_cost: retry cron on PG concurrency errors

### DIFF
--- a/product_replenishment_cost/models/product_template.py
+++ b/product_replenishment_cost/models/product_template.py
@@ -3,8 +3,11 @@
 # directory
 ##############################################################################
 import logging
+import random
+import time
 
 from odoo import _, api, fields, models
+from odoo.service.model import MAX_TRIES_ON_CONCURRENCY_FAILURE, PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
@@ -103,6 +106,43 @@ class ProductTemplate(models.Model):
 
     @api.model
     def cron_update_cost_from_replenishment_cost(self, limit=None, company_ids=None, batch_size=1000):
+        """Reintenta el batch ante errores de concurrencia de PostgreSQL.
+
+        Los crons no reintentan solos como las peticiones HTTP, así que si el batch
+        choca con otro proceso lo reintentamos unas veces antes de dar el job por
+        fallido. Solo mitiga bloqueos pasajeros.
+        """
+        for attempt in range(1, MAX_TRIES_ON_CONCURRENCY_FAILURE + 1):
+            try:
+                return self._cron_update_cost_from_replenishment_cost(
+                    limit=limit, company_ids=company_ids, batch_size=batch_size
+                )
+            except PG_CONCURRENCY_EXCEPTIONS_TO_RETRY as exc:
+                # la transacción quedó abortada: rollback y reset de caché del ORM antes
+                # de reintentar, para releer estado limpio (igual que el core).
+                self.env.cr.rollback()
+                self.env.transaction.reset()
+                if attempt == MAX_TRIES_ON_CONCURRENCY_FAILURE:
+                    _logger.error(
+                        "cron_update_cost_from_replenishment_cost: error de concurrencia (%s) "
+                        "tras %s intentos, se aborta y el job queda fallido.",
+                        exc.__class__.__name__,
+                        MAX_TRIES_ON_CONCURRENCY_FAILURE,
+                    )
+                    raise
+                wait_time = random.uniform(0.0, 2**attempt)
+                _logger.warning(
+                    "cron_update_cost_from_replenishment_cost: error de concurrencia (%s), "
+                    "intento %s/%s, reintentando en %.2fs",
+                    exc.__class__.__name__,
+                    attempt,
+                    MAX_TRIES_ON_CONCURRENCY_FAILURE,
+                    wait_time,
+                )
+                time.sleep(wait_time)
+
+    @api.model
+    def _cron_update_cost_from_replenishment_cost(self, limit=None, company_ids=None, batch_size=1000):
         """vamos a actualizar de a batches y guardar en un parametro cual es el ultimo que se actualizó.
         si hay mas por actualizar llamamos con trigger al mismo cron para que siga con el prox batch
         si terminamos, resetamos el parametro a 0 para que en proxima corrida arranque desde abajo

--- a/product_replenishment_cost/tests/test_product_template.py
+++ b/product_replenishment_cost/tests/test_product_template.py
@@ -1,4 +1,11 @@
+from unittest.mock import patch
+
+import psycopg2
+from odoo.service.model import MAX_TRIES_ON_CONCURRENCY_FAILURE
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+_RETRY_LOGGER = "odoo.addons.product_replenishment_cost.models.product_template"
 
 
 class TestProductTemplate(TransactionCase):
@@ -104,3 +111,57 @@ class TestUpdateCostFromReplenishmentCost(TransactionCase):
         self.product_template._update_cost_from_replenishment_cost()
 
         self.assertEqual(product.standard_price, 80.0)
+
+
+class TestCronUpdateCostRetry(TransactionCase):
+    """Reintento del cron ante errores de concurrencia de PostgreSQL.
+
+    No se puede provocar un SerializationFailure real de forma determinística, así que
+    inyectamos la falla parcheando el helper propio ``_cron_update_cost_from_replenishment_cost``
+    (no primitivas del ORM). La escritura real del batch ya está cubierta por
+    ``TestUpdateCostFromReplenishmentCost``; acá validamos solo el control de reintentos.
+    Además parcheamos ``cr.rollback`` (el framework de tests lo prohíbe) y ``time.sleep``
+    para no penalizar la corrida.
+    """
+
+    @mute_logger(_RETRY_LOGGER)
+    def test_cron_retries_and_succeeds_on_serialization_failure(self):
+        ProductTemplate = self.env["product.template"]
+        calls = {"n": 0}
+
+        def _flaky(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise psycopg2.errors.SerializationFailure()
+            return True
+
+        with patch.object(
+            type(ProductTemplate),
+            "_cron_update_cost_from_replenishment_cost",
+            side_effect=_flaky,
+        ), patch.object(self.env.cr, "rollback", lambda: None), patch("time.sleep", lambda *args: None):
+            result = ProductTemplate.cron_update_cost_from_replenishment_cost(company_ids=[self.env.company.id])
+
+        # un fallo transitorio + un reintento exitoso
+        self.assertEqual(calls["n"], 2)
+        self.assertTrue(result)
+
+    @mute_logger(_RETRY_LOGGER)
+    def test_cron_reraises_after_max_retries(self):
+        ProductTemplate = self.env["product.template"]
+        calls = {"n": 0}
+
+        def _always_fail(*args, **kwargs):
+            calls["n"] += 1
+            raise psycopg2.errors.SerializationFailure()
+
+        with patch.object(
+            type(ProductTemplate),
+            "_cron_update_cost_from_replenishment_cost",
+            side_effect=_always_fail,
+        ), patch.object(self.env.cr, "rollback", lambda: None), patch("time.sleep", lambda *args: None):
+            with self.assertRaises(psycopg2.errors.SerializationFailure):
+                ProductTemplate.cron_update_cost_from_replenishment_cost(company_ids=[self.env.company.id])
+
+        # se agotan los MAX_TRIES intentos antes de relanzar
+        self.assertEqual(calls["n"], MAX_TRIES_ON_CONCURRENCY_FAILURE)


### PR DESCRIPTION
## Problem

The `cron_update_cost_from_replenishment_cost` cron runs a bulk `UPDATE` on `product_product.standard_price`. When another process holds a lock on the same rows, PostgreSQL aborts the transaction with a serialization failure (`could not serialize access due to concurrent update`) or a deadlock.

Unlike HTTP requests —which Odoo retries automatically on these errors (`odoo.service.model.retrying`)— crons get **no** such retry: the exception propagates to the `ir.cron` handler and the job is marked as *failed*, leaving the accounting cost stale until the next scheduled run.

## Solution

Wrap the batch in a retry loop with exponential backoff:

- Reuses core's concurrency error set (`PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`: `SerializationFailure` + `DeadlockDetected` + `LockNotAvailable`) instead of catching a single error type — the same contention can surface as a deadlock.
- Reuses core's `MAX_TRIES_ON_CONCURRENCY_FAILURE` (5) and the `random.uniform(0, 2**attempt)` backoff, mirroring `retrying()`.
- On error: `cr.rollback()` + `transaction.reset()` to re-read clean state before retrying.
- Once retries are exhausted the exception is **re-raised**, so the job ends as failed rather than being silently swallowed.

The original method body moves to a private helper `_cron_update_cost_from_replenishment_cost`; the public method (referenced by the `ir.cron` and by `_trigger()`) keeps its signature.

This mitigates **transient** locks; sustained contention against a specific concurrent writer still needs to be addressed at the source of the lock.

## Test plan

Two new tests in `TestCronUpdateCostRetry`:

- `test_cron_retries_and_succeeds_on_serialization_failure`: transient failure + successful retry.
- `test_cron_reraises_after_max_retries`: exhausts the 5 attempts and re-raises.

The failure is injected by patching the module's own helper (not ORM primitives); the real batch write is already covered by `TestUpdateCostFromReplenishmentCost`. Full module suite green locally (`0 failed, 0 errors`).