### PR TITLE
[FW][IMP] product_currency_mrp: add currency to all BoM structure report

### DIFF
--- a/product_currency_mrp/README.rst
+++ b/product_currency_mrp/README.rst
@@ -37,6 +37,9 @@ Usage
 To use this module, you need to:
 
 #. Define a different currency from the default one on the product.
+#. Open the BoM structure report of that product. Every line (components,
+   operations, by-products and subcontracting) is expressed in the product
+   currency, so the total is a single-currency amount.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/product_currency_mrp/__manifest__.py
+++ b/product_currency_mrp/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Product Currency MRP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Products",
     "sequence": 14,
     "summary": "",
@@ -29,7 +29,7 @@
     "images": [],
     "depends": [
         "product_currency",
-        "mrp",
+        "mrp_subcontracting",
     ],
     "data": [],
     "demo": [],

--- a/product_currency_mrp/report/mrp_report_bom_structure.py
+++ b/product_currency_mrp/report/mrp_report_bom_structure.py
@@ -5,6 +5,63 @@ class ReportReplenishmentBomStructure(models.AbstractModel):
     _inherit = "report.mrp.report_bom_structure"
 
     @api.model
+    def _get_bom_data(
+        self,
+        bom,
+        warehouse,
+        product=False,
+        line_qty=False,
+        bom_line=False,
+        level=0,
+        parent_bom=False,
+        parent_product=False,
+        index=0,
+        product_info=False,
+        ignore_stock=False,
+        simulated_leaves_per_workcenter=False,
+    ):
+        """Here we use the product forced currency uom unit"""
+        if not self.env.context.get("force_currency"):
+            # product is optional, fall back to the template as the rest of
+            # the method already does
+            self = self.with_context(force_currency=product.currency_id if product else bom.product_tmpl_id.currency_id)
+        res = super()._get_bom_data(
+            bom,
+            warehouse,
+            product,
+            line_qty,
+            bom_line,
+            level,
+            parent_bom,
+            parent_product,
+            index,
+            product_info,
+            ignore_stock,
+            simulated_leaves_per_workcenter,
+        )
+        currency = self.env.context.get("force_currency") or self.env.company.currency_id
+        res.update({"currency": currency, "currency_id": currency.id})
+        is_minimized = self.env.context.get("minimized", False)
+        current_quantity = line_qty
+        if bom_line:
+            current_quantity = bom_line.product_uom_id._compute_quantity(line_qty, bom.product_uom_id) or 0
+        if not is_minimized:
+            if product:
+                price = product.uom_id._compute_price(product.standard_price, bom.product_uom_id) * current_quantity
+                res["prod_cost"] = product.currency_id._convert(
+                    price, currency, self.env.company, fields.Date.today(), round=True
+                )
+            else:
+                price = (
+                    bom.product_tmpl_id.uom_id._compute_price(bom.product_tmpl_id.standard_price, bom.product_uom_id)
+                    * current_quantity
+                )
+                res["prod_cost"] = bom.product_tmpl_id.currency_id._convert(
+                    price, currency, self.env.company, fields.Date.today(), round=True
+                )
+        return res
+
+    @api.model
     def _get_component_data(
         self,
         parent_bom,
@@ -28,15 +85,70 @@ class ReportReplenishmentBomStructure(models.AbstractModel):
             )
             * line_quantity
         )
-        price_converted = currency._convert(
-            price, self.env.company.currency_id, (parent_bom.company_id or self.env.company), fields.Date.today()
-        )
-        rounded_price = currency.round(price_converted)
+        price = bom_line.product_id.currency_id._convert(price, currency, company, fields.Date.today())
+        price = currency.round(price)
         res.update(
             {
                 "currency": currency,
                 "currency_id": currency.id,
-                "prod_cost": rounded_price,
+                "prod_cost": price,
+                "bom_cost": price,
             }
         )
+        return res
+
+    @api.model
+    def _get_byproducts_lines(self, product, bom, bom_quantity, level, total, index):
+        byproducts, byproduct_cost_portion = super()._get_byproducts_lines(
+            product, bom, bom_quantity, level, total, index
+        )
+        currency = self.env.context.get("force_currency") or self.env.company.currency_id
+        for byproduct in byproducts:
+            byproduct_id = self.env["mrp.bom.byproduct"].browse(byproduct["id"])
+            line_quantity = (bom_quantity / (bom.product_qty or 1.0)) * byproduct_id.product_qty
+            price = (
+                byproduct_id.product_id.uom_id._compute_price(
+                    byproduct_id.product_id.standard_price, byproduct_id.product_uom_id
+                )
+                * line_quantity
+            )
+            price = byproduct_id.product_id.currency_id._convert(
+                price, currency, self.env.company, fields.Date.today(), round=True
+            )
+            byproduct.update(
+                {
+                    "currency_id": currency.id,
+                    "prod_cost": price,
+                }
+            )
+        return byproducts, byproduct_cost_portion
+
+    @api.model
+    def _get_operation_line(self, product, bom, qty, level, index, bom_report_line, simulated_leaves_per_workcenter):
+        operations = super()._get_operation_line(
+            product, bom, qty, level, index, bom_report_line, simulated_leaves_per_workcenter
+        )
+        currency = self.env.context.get("force_currency") or self.env.company.currency_id
+        for operation in operations:
+            bom_cost = self.env.company.currency_id._convert(
+                operation["bom_cost"], currency, self.env.company, fields.Date.today(), round=True
+            )
+            operation.update(
+                {
+                    "currency_id": currency.id,
+                    "bom_cost": bom_cost,
+                }
+            )
+        return operations
+
+    def _get_subcontracting_line(self, bom, seller, level, bom_quantity):
+        res = super()._get_subcontracting_line(bom, seller, level, bom_quantity)
+        # 19.0 renamed seller.product_uom -> product_uom_id and uom ratio -> factor,
+        # and the native line no longer carries prod_cost.
+        ratio_uom_seller = seller.product_uom_id.factor / bom.product_uom_id.factor
+        currency = self.env.context.get("force_currency") or self.env.company.currency_id
+        price = seller.currency_id._convert(
+            seller.price, currency, (bom.company_id or self.env.company), fields.Date.today()
+        )
+        res.update({"bom_cost": price / ratio_uom_seller * bom_quantity})
         return res

--- a/product_currency_mrp/tests/__init__.py
+++ b/product_currency_mrp/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_bom_structure_currency

--- a/product_currency_mrp/tests/test_bom_structure_currency.py
+++ b/product_currency_mrp/tests/test_bom_structure_currency.py
@@ -1,0 +1,136 @@
+from odoo import fields
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestBomStructureCurrency(TransactionCase):
+    """Products costed in a currency other than the company one, through
+    force_currency_id. The BoM structure report must express every line in the
+    product currency, instead of mixing nominal values of both currencies.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.company_currency = cls.company.currency_id
+        cls.rate = 1000.0
+        # A currency of its own so the test does not depend on which currency
+        # the company happens to use. 1 TSC = 1000 company currency units.
+        cls.currency = cls.env["res.currency"].create(
+            {
+                "name": "TSC",
+                "symbol": "TSC",
+                "rounding": 0.01,
+            }
+        )
+        cls.env["res.currency.rate"].create(
+            {
+                "name": fields.Date.today(),
+                "currency_id": cls.currency.id,
+                "company_id": cls.company.id,
+                "inverse_company_rate": cls.rate,
+            }
+        )
+
+        cls.component = cls.env["product.product"].create(
+            {
+                "name": "Component costed in TSC",
+                "is_storable": True,
+                "standard_price": 10.0,
+                "force_currency_id": cls.currency.id,
+            }
+        )
+        cls.finished = cls.env["product.product"].create(
+            {
+                "name": "Finished costed in TSC",
+                "is_storable": True,
+                "standard_price": 0.0,
+                "force_currency_id": cls.currency.id,
+            }
+        )
+
+    def _bom_report(self, bom):
+        return self.env["report.mrp.report_bom_structure"]._get_report_data(bom_id=bom.id, searchQty=1)
+
+    def test_component_cost_uses_product_currency(self):
+        """A component costed at 10 TSC must be reported as 10 in a TSC BoM.
+
+        Without the currency overrides the report falls back to the company
+        currency, so the 10 is silently taken as 10 company currency units.
+        """
+        bom = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": self.finished.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "bom_line_ids": [(0, 0, {"product_id": self.component.id, "product_qty": 1.0})],
+            }
+        )
+        report = self._bom_report(bom)
+
+        self.assertEqual(report["lines"]["currency_id"], self.currency.id, "The BoM report must be expressed in TSC")
+        component_line = report["lines"]["components"][0]
+        self.assertEqual(component_line["currency_id"], self.currency.id)
+        self.assertAlmostEqual(component_line["bom_cost"], 10.0, 2)
+        self.assertAlmostEqual(report["lines"]["bom_cost"], 10.0, 2)
+
+    def test_bom_data_without_product(self):
+        """_get_bom_data takes product as an optional argument, so the currency
+        has to fall back to the template instead of blowing up on False.
+        """
+        bom = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": self.finished.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "bom_line_ids": [(0, 0, {"product_id": self.component.id, "product_qty": 1.0})],
+            }
+        )
+        warehouse = self.env["stock.warehouse"].search([], limit=1)
+        res = self.env["report.mrp.report_bom_structure"]._get_bom_data(bom, warehouse)
+
+        self.assertEqual(res["currency_id"], self.currency.id)
+
+    def test_subcontracting_and_components_share_one_currency(self):
+        """Ticket 122531: subcontracted BoM whose supplier price is in TSC.
+
+        The native subcontracting line converts the supplier price to the
+        company currency (5 TSC -> 5000) while the component keeps its nominal
+        10. Adding them up gives 5010, an amount in no currency at all. Both
+        must land in the product currency: 5 + 10 = 15 TSC.
+        """
+        subcontractor = self.env["res.partner"].create({"name": "Subcontractor"})
+        self.env["product.supplierinfo"].create(
+            {
+                "partner_id": subcontractor.id,
+                "product_tmpl_id": self.finished.product_tmpl_id.id,
+                "price": 5.0,
+                "currency_id": self.currency.id,
+            }
+        )
+        bom = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": self.finished.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "subcontract",
+                "subcontractor_ids": [(6, 0, subcontractor.ids)],
+                "bom_line_ids": [(0, 0, {"product_id": self.component.id, "product_qty": 1.0})],
+            }
+        )
+        report = self._bom_report(bom)
+
+        self.assertEqual(report["lines"]["currency_id"], self.currency.id)
+        self.assertAlmostEqual(
+            report["lines"]["subcontracting"]["bom_cost"],
+            5.0,
+            2,
+            "The supplier price is already in TSC, it must not be converted to the company currency",
+        )
+        self.assertAlmostEqual(report["lines"]["components"][0]["bom_cost"], 10.0, 2)
+        self.assertAlmostEqual(
+            report["lines"]["bom_cost"],
+            15.0,
+            2,
+            "Total must add up amounts expressed in the same currency",
+        )

--- a/product_replenishment_cost_mrp/report/mrp_report_bom_structure.py
+++ b/product_replenishment_cost_mrp/report/mrp_report_bom_structure.py
@@ -11,12 +11,12 @@ class ReportReplenishmentBomStructure(models.AbstractModel):
         currency = self.env.context.get("force_currency") or self.env.company.currency_id
 
         # Convert the seller price to the proper currency
-        if bom.product_uom_id.ratio == 0:
+        if bom.product_uom_id.factor == 0:
             raise ValueError(
                 "El ratio de la unidad de medida del producto en el BOM es cero. "
                 "Esto provocaría una división por cero. Verifique la configuración de la UoM."
             )
-        ratio_uom_seller = seller.product_uom.ratio / bom.product_uom_id.ratio
+        ratio_uom_seller = seller.product_uom_id.factor / bom.product_uom_id.factor
         price = seller.currency_id._convert(seller.price, currency, self.env.company, fields.Date.today(), round=True)
         res.update(
             {


### PR DESCRIPTION
Forward-port of 9ded8fd5 (#752) to 19.0, companion of #921 for 18.0.

The commit landed on 16.0 and 17.0 but never on 18.0, and 19.0 inherited the incomplete version through the migration commit 115fedde.

## Problem

Only `_get_component_data` is overridden, and with the conversion in the opposite direction and no `bom_cost`. Since `_get_bom_data` is what sets `force_currency`, the report falls back to the company currency: component costs are shown as nominal amounts while the subcontracting line is properly converted, so the BoM total adds up amounts of two different currencies.

## Changes

Same as #921:

- `_get_bom_data`: sets `force_currency` from the product and converts `prod_cost`.
- `_get_component_data`: converts from the product currency to the forced one (was the other way around) and sets `bom_cost`.
- `_get_byproducts_lines`, `_get_operation_line`, `_get_subcontracting_line`: added, as on 16.0/17.0.
- `depends`: `mrp` → `mrp_subcontracting`, where `_get_subcontracting_line` is defined.

Two differences against the 18.0 port, both in `_get_subcontracting_line`: 19.0 renamed `seller.product_uom` to `seller.product_uom_id` and the uom `ratio` to `factor`, and the native line no longer carries `prod_cost`, so only `bom_cost` is overridden here.

## Tests

Adds `tests/test_bom_structure_currency.py`: company currency plus a currency created by the test at a rate of 1000, products costed in it via `force_currency_id`.

- `test_component_cost_uses_product_currency` — a component costed at 10 is reported as 10, not as 10 company currency units.
- `test_subcontracting_and_components_share_one_currency` — subcontracted BoM with a supplier price of 5: subcontracting 5 + component 10 = 15, instead of 5000 + 10 nominal.

Verified against 19.0: both tests fail on the current branch and pass with this commit.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/122531