### PR TITLE
[FIX] price_security: lock partner pricelist for restricted users on v19

### DIFF
--- a/price_security/models/res_partner.py
+++ b/price_security/models/res_partner.py
@@ -23,8 +23,10 @@ class ResPartner(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         if view_type == "form":
             if self.env.user.has_group("price_security.group_only_view"):
-                readonly_fields = arch.xpath("//field[@name='property_product_pricelist']") + arch.xpath(
-                    "//field[@name='property_payment_term_id']"
+                readonly_fields = (
+                    arch.xpath("//field[@name='property_product_pricelist']")
+                    + arch.xpath("//field[@name='specific_property_product_pricelist']")
+                    + arch.xpath("//field[@name='property_payment_term_id']")
                 )
                 for node in readonly_fields:
                     node.set("readonly", "1")


### PR DESCRIPTION
In v19 the editable stored field on the contact form is specific_property_product_pricelist, while property_product_pricelist became a computed/readonly display. The _get_view override was only forcing readonly on property_product_pricelist, leaving the specific field editable, so users in group_only_view could change the customer pricelist from the contact form (and it propagated to sale orders), bypassing the price restriction. Also lock specific_property_product_pricelist.