### PR TITLE
[FIX] product_catalog_tree: don't assume order_line for non order-line models

### DIFF
--- a/product_catalog_tree/models/product_product.py
+++ b/product_catalog_tree/models/product_product.py
@@ -64,23 +64,27 @@ class ProductProduct(models.Model):
             return
 
         order = self.env[res_model].browse(order_id)
+        # Distintos modelos de orden (sale.order, purchase.order, account.move,
+        # repair.order, ...) exponen sus líneas con nombres de campo distintos, por
+        # lo que usamos el hook estándar del catálogo de productos en lugar de
+        # asumir "order_line" (repair.order, por ejemplo, no lo tiene).
+        qty_field = "quantity" if res_model == "account.move" else "product_uom_qty"
+        record_lines = order._get_product_catalog_record_lines(self.ids)
         for rec in self:
-            if res_model == "account.move":
-                existing_lines = order.invoice_line_ids.filtered(lambda line: line.product_id.id == rec.id)
-            else:
-                existing_lines = order.order_line.filtered(lambda line: line.product_id.id == rec.id)
+            existing_lines = record_lines[rec]
             if len(existing_lines) > 1 and product_catalog_qty > 0:
-                total_current_qty = sum(existing_lines.mapped("product_uom_qty"))
+                total_current_qty = sum(existing_lines.mapped(qty_field))
                 qty_difference = product_catalog_qty - total_current_qty
                 if qty_difference >= 0:
-                    existing_lines[0].product_uom_qty += qty_difference
+                    setattr(existing_lines[0], qty_field, getattr(existing_lines[0], qty_field) + qty_difference)
                 else:
                     remaining_to_reduce = abs(qty_difference)
                     for line in existing_lines:
                         if remaining_to_reduce <= 0:
                             break
-                        can_reduce = min(line.product_uom_qty, remaining_to_reduce)
-                        line.product_uom_qty -= can_reduce
+                        current_qty = getattr(line, qty_field)
+                        can_reduce = min(current_qty, remaining_to_reduce)
+                        setattr(line, qty_field, current_qty - can_reduce)
                         remaining_to_reduce -= can_reduce
             else:
                 # Actualizar la información de la línea de orden

--- a/product_catalog_tree/tests/test_product_catalog_tree.py
+++ b/product_catalog_tree/tests/test_product_catalog_tree.py
@@ -125,3 +125,23 @@ class TestProductCatalogTree(TransactionCase):
         catalog_product.increase_quantity()
         line = order.order_line.filtered(lambda line: line.product_id == product)
         self.assertEqual(line.product_qty, 1)
+
+    def test_increase_quantity_on_repair_order_does_not_crash(self):
+        """Regression test: unlike sale/purchase orders, repair.order does not
+        expose an ``order_line`` field (it uses ``move_ids``), which used to
+        crash the catalog's ``+`` button with an AttributeError."""
+        if "repair.order" not in self.env:
+            self.skipTest("repair is not installed")
+
+        product_to_repair = self.env["product.product"].create({"name": "Broken widget"})
+        component = self.env["product.product"].create({"name": "Spare part"})
+        repair = self.env["repair.order"].create({"product_id": product_to_repair.id})
+        catalog_product = component.with_context(
+            product_catalog_order_model="repair.order",
+            order_id=repair.id,
+        )
+
+        catalog_product.increase_quantity()
+
+        move = repair.move_ids.filtered(lambda m: m.product_id == component)
+        self.assertEqual(move.product_uom_qty, 1)


### PR DESCRIPTION
## Resumen

`product.product._inverse_catalog_values()` asumía que cualquier "order" del catálogo de productos expone sus líneas en `order_line` (con un caso especial ya cableado para `account.move` → `invoice_line_ids`). `repair.order` expone sus líneas en `move_ids`, así que agregar un componente desde el catálogo en una orden de reparación explotaba con:

```
AttributeError: 'repair.order' object has no attribute 'order_line'
```

## Fix

En vez de hardcodear el nombre del campo por modelo, se usa el hook estándar de Odoo `_get_product_catalog_record_lines()`, que `sale.order`, `purchase.order`, `account.move` y `repair.order` ya implementan para este mismo propósito. Así el método queda genérico para cualquier modelo que soporte el catálogo de productos.

## Test plan

- Se agregó `test_increase_quantity_on_repair_order_does_not_crash` (regresión: agrega un componente a una `repair.order` vía el catálogo y verifica que no crashee y cree el `stock.move`).
- Corrida completa de la suite del módulo: 4/4 tests OK.