### PR TITLE
[FIX] product_replenishment_cost_mrp: compute BoM based cost record by record

### DIFF
--- a/product_replenishment_cost_mrp/models/product_template.py
+++ b/product_replenishment_cost_mrp/models/product_template.py
@@ -8,6 +8,10 @@ class ProductTemplate(models.Model):
     replenishment_cost_type = fields.Selection(
         selection_add=[("bom", "Basado en Ldm")], ondelete={"bom": "set default"}
     )
+    # computed record by record: the cost of a "Based on BoM" product reads the replenishment cost
+    # of its components, and the ORM returns 0 for the records of the batch being computed
+    replenishment_cost = fields.Float(recursive=True)
+    replenishment_base_cost_on_currency = fields.Float(recursive=True)
 
     @api.onchange("replenishment_cost_type")
     def onchange_replenishment_cost_type(self):

--- a/product_replenishment_cost_mrp/tests/__init__.py
+++ b/product_replenishment_cost_mrp/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_replenishment_cost_bom

--- a/product_replenishment_cost_mrp/tests/test_replenishment_cost_bom.py
+++ b/product_replenishment_cost_mrp/tests/test_replenishment_cost_bom.py
@@ -1,0 +1,92 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestReplenishmentCostBom(TransactionCase):
+    """Costo de reposicion calculado desde la lista de materiales."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.currency = cls.company.currency_id
+
+        cls.raw_1 = cls._create_manual_cost_template("RAW-1", 10.0)
+        cls.raw_2 = cls._create_manual_cost_template("RAW-2", 10.0)
+
+        # un nivel: terminado directo sobre insumos comprados
+        cls.single_level = cls.env["product.template"].create({"name": "SINGLE LEVEL", "default_code": "SINGLE"})
+        cls._create_bom(cls.single_level, [(cls.raw_1, 1), (cls.raw_2, 1)])
+
+        # dos niveles: terminado sobre un sub armado que a su vez sale de su propia LdM
+        cls.sub_assembly = cls.env["product.template"].create({"name": "SUB", "default_code": "SUB"})
+        cls.finished = cls.env["product.template"].create({"name": "FINISHED", "default_code": "FINISHED"})
+        cls._create_bom(cls.sub_assembly, [(cls.raw_1, 1), (cls.raw_2, 1)])
+        cls._create_bom(cls.finished, [(cls.sub_assembly, 1), (cls.raw_1, 1)])
+
+        (cls.single_level + cls.sub_assembly + cls.finished).replenishment_cost_type = "bom"
+
+    @classmethod
+    def _create_manual_cost_template(cls, default_code, cost):
+        return cls.env["product.template"].create(
+            {
+                "name": default_code,
+                "default_code": default_code,
+                "replenishment_cost_type": "manual",
+                "replenishment_base_cost": cost,
+                "replenishment_base_cost_currency_id": cls.currency.id,
+            }
+        )
+
+    @classmethod
+    def _create_bom(cls, template, lines):
+        return cls.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": template.id,
+                "product_qty": 1,
+                "type": "normal",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": component.product_variant_id.id, "product_qty": qty})
+                    for component, qty in lines
+                ],
+            }
+        )
+
+    def test_single_level_bom(self):
+        self.env.invalidate_all()
+        self.assertEqual(self.single_level.replenishment_cost, 20.0)
+
+    def test_multi_level_bom(self):
+        self.env.invalidate_all()
+        self.assertEqual(self.sub_assembly.replenishment_cost, 20.0)
+        self.env.invalidate_all()
+        self.assertEqual(self.finished.replenishment_cost, 30.0)
+
+    def test_multi_level_bom_computed_as_batch(self):
+        """El sub armado y el terminado en el mismo lote no deben perder el costo del sub armado.
+
+        Hay que iterar el recordset: browse() resetea el prefetch set y computa de a uno, que es
+        justamente el escenario que no falla.
+        """
+        self.env.invalidate_all()
+        templates = self.finished + self.sub_assembly + self.raw_1 + self.raw_2
+        costs = {template.default_code: template.replenishment_cost for template in templates}
+        self.assertEqual(costs["SUB"], 20.0)
+        self.assertEqual(costs["FINISHED"], 30.0)
+
+    def test_update_cost_computed_as_batch(self):
+        """La accion sobre una seleccion que incluye toda la cadena debe grabar el costo completo."""
+        self.env.invalidate_all()
+        templates = self.finished + self.sub_assembly + self.raw_1 + self.raw_2
+        templates._update_cost_from_replenishment_cost()
+        self.assertEqual(self.sub_assembly.product_variant_id.standard_price, 20.0)
+        self.assertEqual(self.finished.product_variant_id.standard_price, 30.0)
+
+    def test_product_without_bom(self):
+        no_bom = self.env["product.template"].create({"name": "NO BOM", "default_code": "NO-BOM"})
+        no_bom.replenishment_cost_type = "bom"
+        self.env.invalidate_all()
+        self.assertEqual(no_bom.replenishment_cost, 0.0)


### PR DESCRIPTION
Un producto con costo de reposición **"Basado en LdM"** lee el costo de reposición de sus componentes, y un componente puede ser a su vez "Basado en LdM". Los campos no estaban declarados `recursive`, así que el ORM los computaba de a lotes y protegía el lote entero: leer el campo sobre un registro del lote que todavía no se computó devuelve **0 sin error**, y el padre pierde en silencio el costo de ese componente.

Solo se manifiesta cuando no queda ningún componente de la cadena fuera del lote que lo resuelva. Por eso la ficha del producto siempre da bien, la acción contextual falla solo si se selecciona toda la cadena, y la acción planificada —que recorre el catálogo entero— falla siempre. El valor tampoco es estable entre corridas: depende de qué productos caen en el mismo lote y del orden en que se leen, que difiere entre `product.product` (por `default_code`) y `product.template` (por `name`).

## El cambio

Declarar `recursive=True` sobre `replenishment_cost` y `replenishment_base_cost_on_currency` (comparten compute, la protección los agrupa). El ORM pasa a computarlos de a un registro: la protección cubre un solo record y la lectura del componente lo computa en vez de devolver cero.

La declaración va en **este** módulo y no en `product_replenishment_cost` porque la recursión la introduce acá: sin costo basado en LdM ningún producto lee el campo de otro, y las bases que no fabrican no pagan el costo.

## Alternativas descartadas

- **Ordenar el proceso, componentes primero:** la protección aplica al lote completo sin importar el orden, y el padre no lee el costo contable ya grabado del componente sino que le pide recalcular el costo de reposición.
- **Achicar los lotes:** reduce la probabilidad pero no la elimina; deja un bug intermitente en vez de uno consistente.
- **Almacenar el campo:** el costo depende de la compañía activa y de la cotización del día, así que un valor almacenado no puede depender del contexto. Es otro alcance.
- **Calcular el costo del componente sin leer el campo:** duplica la lógica y recalcula el árbol entero por cada padre.

## Test plan

Dos tests nuevos en `test_replenishment_cost_bom.py`, ambos sobre un terminado (30) construido sobre un sub armado (20) más un insumo (10). Hay que **iterar el recordset**: `browse()` resetea el prefetch set y computa de a uno, que es justamente el escenario que no falla.

- `test_multi_level_bom_computed_as_batch` — lectura del campo con toda la cadena en el mismo lote.
- `test_update_cost_computed_as_batch` — la acción que graba el costo contable sobre esa misma selección.

Sin el fix ambos dan `10.0 != 30.0`. Con el fix pasan los 5 del módulo, más los 16 de `product_replenishment_cost`.

## Medición

Catálogo sintético de 2000 productos, 1000 de ellos "Basado en LdM" (500 sub armados y 500 terminados construidos sobre esos sub armados). Leyendo los 1000 juntos, que es lo que hace la acción planificada:

| | Terminados correctos | Costo total | Mejor de 3 corridas |
|---|---|---|---|
| Sin el fix | 0/500 | 5000 (debería ser 15000) | 6,13s |
| Con el fix | 500/500 | 15000 | 6,99s |

**+14% de tiempo.** Sobre los 2000 productos mezclados el overhead baja a +10%, porque los productos con costo manual o de proveedor no cambian de comportamiento.

## Nota para el reviewer

- No depende de #930: lo que ese PR toca en este módulo es refactor de legibilidad del `_bom_find`, en otra parte del archivo. Este se para solo sobre `18.0`.
- Trae también el fixture y las pruebas base del módulo, que originalmente venían en #930. Cuando este mergee, #930 tiene que descartar `tests/__init__.py` y `tests/test_replenishment_cost_bom.py` en su rebase: esa cobertura ya queda incluida acá.
- El cambio toca definición de campos, así que corresponde `bump`.

