### PR TITLE
[FIX] price_security: hide inventory valuation costs from restricted users

### DIFF
--- a/price_security/README.rst
+++ b/price_security/README.rst
@@ -50,6 +50,15 @@ For users with price restriction, it restricts:
 #. on invoice lines: change unit price and set limits on discount (limits configured on user)
 #. on product: change price
 
+For users with "Only see: sale price", it also hides the cost from the lists they can
+reach: the accounting cost and the inventory valuation columns (unit cost and total
+value) on the product and stock report lists, the value on the quant lists, and the
+valuation fields on the lot form. The secondary currency counterparts added by
+stock_currency_valuation are hidden too when that module is installed.
+
+Note that this is interface level security: the fields are hidden from the views, but
+the data can still be reached through exports, filters or groupings.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: http://runbot.adhoc.com.ar/

--- a/price_security/models/__init__.py
+++ b/price_security/models/__init__.py
@@ -13,3 +13,5 @@ from . import res_partner
 from . import res_users
 from . import sale_order
 from . import sale_order_line
+from . import stock_lot
+from . import stock_quant

--- a/price_security/models/price_security_utils.py
+++ b/price_security/models/price_security_utils.py
@@ -1,0 +1,17 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+
+def hide_cost_fields(arch, view_type, field_names):
+    """Hide cost fields from users that can only see the sale price.
+
+    On list views the attribute has to be "column_invisible": "invisible" is
+    evaluated per record, so it only blanks the cells and leaves the header,
+    the optional columns toggle and the footer sum in place.
+    """
+    attribute = "column_invisible" if view_type == "list" else "invisible"
+    for field_name in field_names:
+        for node in arch.xpath("//field[@name='%s']" % field_name):
+            node.set(attribute, "1")

--- a/price_security/models/product_product.py
+++ b/price_security/models/product_product.py
@@ -2,6 +2,21 @@ import json
 
 from odoo import api, models
 
+from .price_security_utils import hide_cost_fields
+
+# the accounting cost, plus the inventory valuation columns that stock_account
+# adds to the stock report lists. The "in currency" ones come from
+# stock_currency_valuation, which we do not depend on: the xpath is a no-op when
+# the module is not installed
+LIST_COST_FIELDS = (
+    "standard_price",
+    "avg_cost",
+    "total_value",
+    "standard_price_in_currency",
+    "avg_cost_in_currency",
+    "total_value_in_currency",
+)
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -45,6 +60,8 @@ class ProductProduct(models.Model):
                     + arch.xpath("//field[@name='uom_po_id']")
                     + arch.xpath("//label[@for='standard_price']")
                     + arch.xpath("//field[@name='standard_price']")
+                    + arch.xpath("//label[@for='standard_price_in_currency']")
+                    + arch.xpath("//field[@name='standard_price_in_currency']")
                 )
                 for node in invisible_fields:
                     node.set("invisible", "1")
@@ -53,9 +70,5 @@ class ProductProduct(models.Model):
                     node.set("modifiers", json.dumps(modifiers))
         if view_type == "list":
             if self.env.user.has_group("price_security.group_only_view_sale_price"):
-                for node in arch.xpath("//field[@name='standard_price']"):
-                    node.set("invisible", "1")
-                    modifiers = json.loads(node.get("modifiers") or "{}")
-                    modifiers["invisible"] = True
-                    node.set("modifiers", json.dumps(modifiers))
+                hide_cost_fields(arch, view_type, LIST_COST_FIELDS)
         return arch, view

--- a/price_security/models/product_template.py
+++ b/price_security/models/product_template.py
@@ -6,6 +6,21 @@ import json
 
 from odoo import api, fields, models
 
+from .price_security_utils import hide_cost_fields
+
+# the accounting cost, plus the inventory valuation columns that stock_account
+# adds to the stock report lists. The "in currency" ones come from
+# stock_currency_valuation, which we do not depend on: the xpath is a no-op when
+# the module is not installed
+LIST_COST_FIELDS = (
+    "standard_price",
+    "avg_cost",
+    "total_value",
+    "standard_price_in_currency",
+    "avg_cost_in_currency",
+    "total_value_in_currency",
+)
+
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
@@ -54,6 +69,8 @@ class ProductTemplate(models.Model):
                     + arch.xpath("//field[@name='uom_po_id']")
                     + arch.xpath("//label[@for='standard_price']")
                     + arch.xpath("//field[@name='standard_price']")
+                    + arch.xpath("//label[@for='standard_price_in_currency']")
+                    + arch.xpath("//field[@name='standard_price_in_currency']")
                 )
                 for node in invisible_fields:
                     node.set("invisible", "1")
@@ -62,9 +79,5 @@ class ProductTemplate(models.Model):
                     node.set("modifiers", json.dumps(modifiers))
         if view_type == "list":
             if self.env.user.has_group("price_security.group_only_view_sale_price"):
-                for node in arch.xpath("//field[@name='standard_price']"):
-                    node.set("invisible", "1")
-                    modifiers = json.loads(node.get("modifiers") or "{}")
-                    modifiers["invisible"] = True
-                    node.set("modifiers", json.dumps(modifiers))
+                hide_cost_fields(arch, view_type, LIST_COST_FIELDS)
         return arch, view

--- a/price_security/models/stock_lot.py
+++ b/price_security/models/stock_lot.py
@@ -1,0 +1,29 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+from .price_security_utils import hide_cost_fields
+
+# inventory valuation fields added by stock_account on the lot form
+COST_FIELDS = ("total_value", "avg_cost", "standard_price")
+
+
+class StockLot(models.Model):
+    _inherit = "stock.lot"
+
+    @api.model
+    def _get_view_cache_key(self, view_id=None, view_type="form", **options):
+        """The view is modified for price security users, so it can not be
+        shared with the rest of the users
+        """
+        key = super()._get_view_cache_key(view_id, view_type, **options)
+        return key + (self.env.user.has_group("price_security.group_only_view_sale_price"),)
+
+    @api.model
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if self.env.user.has_group("price_security.group_only_view_sale_price"):
+            hide_cost_fields(arch, view_type, COST_FIELDS)
+        return arch, view

--- a/price_security/models/stock_quant.py
+++ b/price_security/models/stock_quant.py
@@ -1,0 +1,31 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+from .price_security_utils import hide_cost_fields
+
+# inventory valuation columns on the quant lists: "value" from stock_account and
+# "secondary_value" from stock_currency_valuation (not a dependency, the xpath is
+# a no-op when that module is not installed)
+COST_FIELDS = ("value", "secondary_value")
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    @api.model
+    def _get_view_cache_key(self, view_id=None, view_type="form", **options):
+        """The view is modified for price security users, so it can not be
+        shared with the rest of the users
+        """
+        key = super()._get_view_cache_key(view_id, view_type, **options)
+        return key + (self.env.user.has_group("price_security.group_only_view_sale_price"),)
+
+    @api.model
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if self.env.user.has_group("price_security.group_only_view_sale_price"):
+            hide_cost_fields(arch, view_type, COST_FIELDS)
+        return arch, view

--- a/price_security/tests/__init__.py
+++ b/price_security/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_cost_visibility
 from . import test_discount_restriction

--- a/price_security/tests/test_cost_visibility.py
+++ b/price_security/tests/test_cost_visibility.py
@@ -1,0 +1,68 @@
+from lxml import etree
+from odoo.tests import TransactionCase, new_test_user, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCostVisibility(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.restricted_user = new_test_user(
+            cls.env,
+            login="price_security_stock_user",
+            groups="base.group_user,stock.group_stock_manager,price_security.group_only_view_sale_price",
+        )
+
+    def _get_list_arch(self, model, view_xmlid):
+        view = self.env.ref(view_xmlid)
+        arch = self.env[model].with_user(self.restricted_user).get_view(view.id, "list")["arch"]
+        return etree.fromstring(arch)
+
+    def _assert_columns_hidden(self, arch, field_names):
+        for field_name in field_names:
+            nodes = arch.xpath("//field[@name='%s']" % field_name)
+            self.assertTrue(nodes, "%s is expected on the view" % field_name)
+            for node in nodes:
+                # column_invisible is what actually drops the column: invisible
+                # would leave the header, the optional toggle and the footer sum
+                self.assertEqual(
+                    node.get("column_invisible"),
+                    "1",
+                    "%s must be hidden for users that only see the sale price" % field_name,
+                )
+
+    def test_stock_report_hides_cost_columns(self):
+        """The stock report (Inventory > Reporting > Stock) must not leak the
+        valuation columns that stock_account adds to it
+        """
+        arch = self._get_list_arch("product.product", "stock.product_product_stock_tree")
+        self._assert_columns_hidden(arch, ("avg_cost", "total_value"))
+        # the secondary currency ones only exist with stock_currency_valuation
+        in_currency = [
+            f for f in ("avg_cost_in_currency", "total_value_in_currency") if f in self.env["product.product"]._fields
+        ]
+        self._assert_columns_hidden(arch, in_currency)
+
+    def test_quant_list_hides_value(self):
+        arch = self._get_list_arch("stock.quant", "stock.view_stock_quant_tree_editable")
+        self._assert_columns_hidden(arch, ("value",))
+        if "secondary_value" in self.env["stock.quant"]._fields:
+            self._assert_columns_hidden(arch, ("secondary_value",))
+
+    def test_lot_form_hides_cost(self):
+        view = self.env.ref("stock.view_production_lot_form")
+        arch = self.env["stock.lot"].with_user(self.restricted_user).get_view(view.id, "form")["arch"]
+        arch = etree.fromstring(arch)
+        for field_name in ("total_value", "avg_cost", "standard_price"):
+            nodes = arch.xpath("//field[@name='%s']" % field_name)
+            self.assertTrue(nodes, "%s is expected on the lot form" % field_name)
+            for node in nodes:
+                self.assertEqual(node.get("invisible"), "1")
+
+    def test_unrestricted_user_still_sees_cost(self):
+        arch = etree.fromstring(
+            self.env["product.product"].get_view(self.env.ref("stock.product_product_stock_tree").id, "list")["arch"]
+        )
+        nodes = arch.xpath("//field[@name='total_value']")
+        self.assertTrue(nodes)
+        self.assertNotEqual(nodes[0].get("column_invisible"), "1")


### PR DESCRIPTION
Users with the "Only see: sale price" restriction could still read the cost from
Inventory > Reporting > Stock. `stock_account` adds `avg_cost` ("Unit Cost") and
`total_value` ("Total Value") to `stock.product_product_stock_tree` with
`optional="show"`, and `price_security` only hid `standard_price` on lists.

While fixing that, a second issue showed up: the list hiding was done with
`invisible`, which since Odoo 17 is evaluated per record. It blanks the cells but
leaves the column header, the entry in the optional columns dropdown and the
footer `sum` in place. `column_invisible` is what actually drops the column
(`web/static/src/views/list/list_renderer.js`, `getActiveColumns` and
`optionalFieldGroups`).

The same leak was covered on the sibling lists reachable with the same
permissions: `value` on the quant lists and the valuation fields on the lot form.

`stock_currency_valuation` adds the secondary currency counterparts to those same
views (`avg_cost_in_currency` and `total_value_in_currency` on the stock report,
`secondary_value` on the quant lists, `standard_price_in_currency` on the product
form), so they are hidden as well. It is not a dependency of this module: the
xpath is simply a no-op when it is not installed.

Not a v19 regression: the columns are already there in 18.0 with the same
`optional="show"`.

### Changes

- `price_security_utils.hide_cost_fields`: shared helper, picks
  `column_invisible` on lists and `invisible` elsewhere.
- `product.product` / `product.template`: hide `standard_price`, `avg_cost` and
  `total_value` on lists.
- `stock.quant` (new): hide `value` and `secondary_value`.
- `stock.lot` (new): hide `total_value`, `avg_cost`, `standard_price`.
- README: document the new scope and state explicitly that this is interface
  level security — the data is still reachable through exports, filters or
  groupings.

### Test plan

As a user with "Only see: sale price" and Inventory/Administrator:

1. Inventory > Reporting > Stock — no Unit Cost / Total Value columns, and they
   are not offered in the optional columns dropdown.
2. Inventory > Operations > Physical Inventory — no Value column.
3. A valuated lot form — no valuation fields.
4. With an unrestricted user, all of the above are still visible.
