### PR TITLE
[FIX] stock_account_cost_revaluation: link the revaluation entry to the value adjustment

### DIFF
--- a/stock_account_cost_revaluation/README.rst
+++ b/stock_account_cost_revaluation/README.rst
@@ -28,6 +28,10 @@ Características
   cuenta de una ubicación de scrap/ajuste: sin cuenta, sin asiento). No se usa la
   cuenta de variación de stock (pertenece al cierre continental) ni la de
   diferencia de precio (se usa para la diferencia de precio de compras / PPV).
+- El asiento queda **vinculado al ``product.value``** que el estándar registra por
+  el cambio de costo (campo ``account_move_id``, que aporta ``stock_account_ux``).
+  Sin ese vínculo el ajuste sigue figurando como pendiente en el reporte de
+  valuación y el cierre de inventario lo vuelve a contabilizar.
 - **No** genera asiento (por diseño): productos con costeo FIFO
   (``standard_price`` es informativo), categorías con valoración periódica (lo
   materializa el cierre de inventario), productos sin stock on hand y categorías
@@ -38,9 +42,10 @@ Detalles Técnicos
 
 - Modelos heredados:
 
-  - ``product.product``: override de ``_change_standard_price`` y método
+  - ``product.product``: override de ``_change_standard_price``, método
     ``_create_cost_revaluation_entry`` que arma y postea el ``account.move`` de
-    revaluación.
+    revaluación, y ``_link_cost_revaluation_entry`` que lo deja apuntado en el
+    ``product.value`` del cambio de costo.
   - ``product.category``: campo nuevo ``property_cost_revaluation_account_id``
     ("Cost Revaluation Account"), Many2one a ``account.account``,
     company-dependent.

--- a/stock_account_cost_revaluation/__manifest__.py
+++ b/stock_account_cost_revaluation/__manifest__.py
@@ -8,7 +8,10 @@
     "contable (standard_price) de productos con categoría de valoración perpetua "
     "(real_time), en costeo estándar o promedio (AVCO).",
     "depends": [
-        "stock_account",
+        # ``product.value.account_move_id``, the field this module writes the
+        # revaluation entry into. It is ``auto_install`` over ``stock_account``, so
+        # declaring it costs nothing and makes the field guaranteed.
+        "stock_account_ux",
     ],
     "data": [
         "views/product_category_views.xml",

--- a/stock_account_cost_revaluation/models/product_product.py
+++ b/stock_account_cost_revaluation/models/product_product.py
@@ -34,8 +34,43 @@ class ProductProduct(models.Model):
         for product in self:
             if product not in old_price:
                 continue
-            product._create_cost_revaluation_entry(old_price[product])
+            entry = product._create_cost_revaluation_entry(old_price[product])
+            product._link_cost_revaluation_entry(entry)
         return res
+
+    def _link_cost_revaluation_entry(self, entry):
+        """Point the price change's ``product.value`` at the entry that booked it.
+
+        The standard records every price change as a ``product.value`` and leaves the
+        accounting to the inventory closing, so ``stock_account_ux`` reads "no entry" as
+        "still part of the difference to adjust". An adjustment this module already
+        booked has to say so: otherwise it shows up as pending in the valuation report
+        and the closing books it a second time (functional feedback, task 64440).
+
+        The record is the one the standard ``_change_standard_price`` just created for
+        this product: the most recent price change of the company still without an
+        entry. Lot price changes are left out —they get their own ``product.value``—
+        because this entry values the product's on-hand stock, not a lot's.
+        """
+        self.ensure_one()
+        if not entry:
+            return
+        product_value = (
+            self.env["product.value"]
+            .sudo()
+            .search(
+                [
+                    ("product_id", "=", self.id),
+                    ("move_id", "=", False),
+                    ("lot_id", "=", False),
+                    ("company_id", "=", entry.company_id.id),
+                    ("account_move_id", "=", False),
+                ],
+                order="date desc, id desc",
+                limit=1,
+            )
+        )
+        product_value.account_move_id = entry
 
     def _create_cost_revaluation_entry(self, old_price):
         """Contabiliza la diferencia de valuación de inventario por el cambio de

--- a/stock_account_cost_revaluation/tests/test_cost_revaluation.py
+++ b/stock_account_cost_revaluation/tests/test_cost_revaluation.py
@@ -160,3 +160,30 @@ class TestCostRevaluation(TransactionCase):
         before = self._journal_moves_count()
         product.standard_price = 15.0
         self.assertEqual(self._journal_moves_count(), before, "Sin stock on hand no debe generar asiento")
+
+    def test_revaluation_entry_is_linked_to_the_product_value(self):
+        """The price change is recorded as a ``product.value`` and this entry is what
+        booked it. Without the link the adjustment stays "pending" for the valuation
+        report and the closing books it a second time (functional feedback, task
+        64440)."""
+        product = self._product(self._categ("standard", "real_time"))
+        product.standard_price = 15.0
+
+        product_value = self.env["product.value"].search(
+            [("product_id", "=", product.id), ("move_id", "=", False)], order="id desc", limit=1
+        )
+        move = self.env["account.move"].search([("journal_id", "=", self.stock_journal.id)], order="id desc", limit=1)
+        self.assertTrue(move, "The price change has to post the revaluation entry")
+        self.assertEqual(product_value.account_move_id, move)
+
+    def test_product_value_stays_pending_without_entry(self):
+        """No entry, nothing to link: the adjustment stays pending, which is exactly what
+        the valuation report has to keep showing."""
+        product = self._product(self._categ("standard", "real_time", revaluation_account=False))
+        product.standard_price = 15.0
+
+        product_value = self.env["product.value"].search(
+            [("product_id", "=", product.id), ("move_id", "=", False)], order="id desc", limit=1
+        )
+        self.assertTrue(product_value, "The standard records the price change anyway")
+        self.assertFalse(product_value.account_move_id)


### PR DESCRIPTION
Changing the accounting cost (`standard_price`) of a product with perpetual valuation posts the revaluation entry in this module, but the `product.value` the standard records for that same price change was left with no reference to it.

`stock_account_ux` reads "no entry" as "still part of the difference to adjust", so the adjustment kept showing up as pending in the inventory valuation report and the inventory closing booked it a second time. Telling booked from pending is the whole point of that field.

### What changes

- `_link_cost_revaluation_entry` points the `product.value` at the entry right after posting it: the most recent price change of the product in the company still without an entry, which is the one `_change_standard_price` just created.
- Lot price changes are left alone — they record their own `product.value`, and this entry values the product's on-hand stock, not a lot's.
- When no entry is posted (no revaluation account, no stock, FIFO, periodic category) there is nothing to link and the adjustment stays pending, as it should.
- `stock_account_ux` joins `depends`: it is where `account_move_id` comes from. It is `auto_install` over `stock_account`, which this module already depends on, so it is installed in every database that has this one anyway.

### Test plan

2 new tests in `test_cost_revaluation`, 9 green in the module on a fresh database with demo data. The linking one is red without the fix.

### Related

Same branch name as, and part of the same functional review round as, ingadhoc/account-financial-tools#984 and ingadhoc/stock#1004 — runbot builds the three together.

Task: https://www.adhoc.inc/odoo/project.task/64440
