### PR TITLE
[FIX] price_security_sale_triple_discount: settle line amounts with the discount

### DIFF
--- a/price_security_sale_triple_discount/models/sale_order_line.py
+++ b/price_security_sale_triple_discount/models/sale_order_line.py
@@ -18,5 +18,6 @@ class SaleOrderLine(models.Model):
         super()._price_security_settle_discount(vals_list)
         discount_fields = {"discount", "discount1", "discount2", "discount3"}
         to_settle = self.browse(line.id for line, vals in zip(self, vals_list) if not discount_fields & vals.keys())
-        for fname in to_settle and ("discount1", "discount2", "discount3", "discount") or ():
+        amount_fields = ("price_subtotal", "price_total", "price_reduce_taxexcl", "price_reduce_taxinc")
+        for fname in to_settle and ("discount1", "discount2", "discount3", "discount") + amount_fields or ():
             self.env.add_to_compute(self._fields[fname], to_settle)


### PR DESCRIPTION
Ticket 126556: on a wholesale website the cart line showed the list price while the order total applied the pricelist discount, so the same product displayed two different prices.

## Cause

`_price_security_settle_discount` re-marks the discount fields to compute, so the restriction check of `price_security` reads them settled instead of transient. The stored amounts depend on `discount` but had already been computed with its transient value, and re-marking `discount` alone does not propagate to them. The line ended up stored with `discount` correct and `price_subtotal` ignoring it, until any later write on the line recomputed them — an untouched web cart kept the wrong subtotal.

Only databases with both `price_security` and `sale_triple_discount` are affected: this module is the auto_install glue between them. Uninstalling `price_security` clears the symptom, and `sale_triple_discount` alone never shows it.

## Fix

Re-mark the amounts along with the discounts, so they recompute once the discount settles. `price_reduce_taxexcl` and `price_reduce_taxinc` are stored with the same dependency and were stale for the same reason.

## Test plan

Verified on a 19.0 database with a pricelist applying a 23% discount and a user without price restrictions:

| | stored `price_subtotal` |
|---|---|
| before | 200.00 (23% discount ignored) |
| after | 154.00 |

A cart line created through `/shop/cart/add` reproduces it; any later write on the line masks it. The 6 existing tests of `price_security` and this module stay green.

https://www.adhoc.inc/odoo/helpdesk.ticket/126556